### PR TITLE
Fix cross build and bump v to v2.0.1

### DIFF
--- a/.github/workflows/release_sonatype.yml
+++ b/.github/workflows/release_sonatype.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Clean previous local bundle
         run: find . -type d -path "*/target/sonatype-staging" -prune -exec rm -rf {} + || true
 
-      - name: Test + publish signed (core 2.12 + sbt plugin)
-        run: sbt "; project rewriterCore; ++2.12.21 test; ++2.12.21 publishSigned; project sbtPlugin; clean; publishSigned"
+      - name: Test + publish signed (core 2.11/2.12/2.13 + sbt plugin)
+        run: sbt "; project rewriterCore; +test; +publishSigned; project sbtPlugin; clean; publishSigned"
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable user-facing changes to **jacoco-method-filter** are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/).
 
-## [Unreleased] — 2.0.0
+## [Unreleased]
+
+## [2.0.1] — 2026-02-14
+
+### Fixed
+
+- Release workflow now cross-publishes core library for **all three** Scala versions (2.11, 2.12, 2.13). Previously only the 2.12 artifact was published to Maven Central.
+
+## [2.0.0] — 2025-02-14
 
 ### Added
 
@@ -69,7 +77,9 @@ This project uses [Semantic Versioning](https://semver.org/).
 - Rule syntax: `<class>#<method>(<descriptor>)` with glob patterns.
 - `@CoverageGenerated` annotation injection.
 
-[Unreleased]: https://github.com/MoranaApps/jacoco-method-filter/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/MoranaApps/jacoco-method-filter/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/MoranaApps/jacoco-method-filter/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/MoranaApps/jacoco-method-filter/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/MoranaApps/jacoco-method-filter/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/MoranaApps/jacoco-method-filter/compare/v0.1.7...v1.0.0
 [0.1.7]: https://github.com/MoranaApps/jacoco-method-filter/compare/0.1.0...v0.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Release workflow now cross-publishes core library for **all three** Scala versions (2.11, 2.12, 2.13). Previously only the 2.12 artifact was published to Maven Central.
+- Release workflow now cross-publishes core library for **all three** Scala versions (2.11, 2.12, 2.13).
+ Previously only the 2.12 artifact was published to Maven Central.
 
 ## [2.0.0] — 2025-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,8 +78,8 @@ This project uses [Semantic Versioning](https://semver.org/).
 - Rule syntax: `<class>#<method>(<descriptor>)` with glob patterns.
 - `@CoverageGenerated` annotation injection.
 
-[Unreleased]: https://github.com/MoranaApps/jacoco-method-filter/compare/v2.0.1...HEAD
-[2.0.1]: https://github.com/MoranaApps/jacoco-method-filter/compare/v2.0.0...v2.0.1
+[Unreleased]: https://github.com/MoranaApps/jacoco-method-filter/compare/v2.0.0...HEAD
+[2.0.1]: https://github.com/MoranaApps/jacoco-method-filter/compare/v2.0.0...HEAD
 [2.0.0]: https://github.com/MoranaApps/jacoco-method-filter/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/MoranaApps/jacoco-method-filter/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/MoranaApps/jacoco-method-filter/compare/v0.1.7...v1.0.0

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -49,11 +49,11 @@ Artifacts will appear in:
 ```scala
 // project/plugins.sbt
 resolvers += Resolver.defaultLocal
-addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.0")
+addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.1")
 
 // build.sbt
 enablePlugins(morana.coverage.JacocoFilterPlugin)
-libraryDependencies += "io.github.moranaapps" %% "jacoco-method-filter-core" % "2.0.0"
+libraryDependencies += "io.github.moranaapps" %% "jacoco-method-filter-core" % "2.0.1"
 ```
 
 #### Maven (local snapshot)
@@ -74,7 +74,7 @@ libraryDependencies += "io.github.moranaapps" %% "jacoco-method-filter-core" % "
   <dependency>
     <groupId>io.github.moranaapps</groupId>
     <artifactId>jacoco-method-filter-core_2.13</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </dependency>
 </dependencies>
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtassembly.AssemblyPlugin.autoImport._
 ThisBuild / organization   := "io.github.moranaapps"
 ThisBuild / scalaVersion   := "2.12.21"             // default
 ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.21", "2.13.16")
-ThisBuild / version        := "2.0.0"
+ThisBuild / version        := "2.0.1"
 ThisBuild / versionScheme  := Some("early-semver")
 
 // Central (bundle flow)

--- a/examples/maven-basic/pom.xml
+++ b/examples/maven-basic/pom.xml
@@ -78,7 +78,7 @@
                     <plugin>
                         <groupId>io.github.moranaapps</groupId>
                         <artifactId>jacoco-method-filter-maven-plugin</artifactId>
-                        <version>2.0.0</version>
+                        <version>2.0.1</version>
                         <executions>
                             <!-- Rewrite: annotate methods matching rules -->
                             <execution>

--- a/examples/maven-scala/pom.xml
+++ b/examples/maven-scala/pom.xml
@@ -111,7 +111,7 @@
                     <plugin>
                         <groupId>io.github.moranaapps</groupId>
                         <artifactId>jacoco-method-filter-maven-plugin</artifactId>
-                        <version>2.0.0</version>
+                        <version>2.0.1</version>
                         <executions>
                             <!-- Rewrite: annotate methods matching rules -->
                             <execution>

--- a/examples/sbt-basic/project/plugins.sbt
+++ b/examples/sbt-basic/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.0")
+addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.1")
 

--- a/integration-tests/fixtures/sbt-basic/project/plugins.sbt
+++ b/integration-tests/fixtures/sbt-basic/project/plugins.sbt
@@ -1,4 +1,4 @@
 // CI fixture: plugin dependency is enabled (unlike examples/sbt-basic where it is
 // commented out for safe cloning).  Integration tests copy this directory instead
 // of using fragile sed-based uncommenting.
-addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.0")
+addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.1")

--- a/integration-tests/fixtures/sbt-scala211/project/plugins.sbt
+++ b/integration-tests/fixtures/sbt-scala211/project/plugins.sbt
@@ -1,2 +1,2 @@
 // Reference local publish of jacoco-method-filter-sbt plugin
-addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.0")
+addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.1")

--- a/integration-tests/test-maven-report-custom.sh
+++ b/integration-tests/test-maven-report-custom.sh
@@ -87,7 +87,7 @@ cat > pom-custom.xml << 'EOF'
             <plugin>
                 <groupId>io.github.moranaapps</groupId>
                 <artifactId>jacoco-method-filter-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.0.1</version>
                 <executions>
                     <execution>
                         <id>filter-coverage</id>

--- a/maven-plugin/README.md
+++ b/maven-plugin/README.md
@@ -18,7 +18,7 @@ Maven plugin for filtering JaCoCo coverage by annotating methods based on config
 
 - Java 8 or higher
 - Maven 3.6 or higher
-- `jacoco-method-filter-core_2.12:2.0.0` dependency (automatically included)
+- `jacoco-method-filter-core_2.12:2.0.1` dependency (automatically included)
 - JaCoCo CLI 0.8.14 (automatically included)
 
 ## Implementation Details
@@ -60,7 +60,7 @@ Add to your `pom.xml` (recommended: inside a coverage profile):
         <plugin>
           <groupId>io.github.moranaapps</groupId>
           <artifactId>jacoco-method-filter-maven-plugin</artifactId>
-          <version>2.0.0</version>
+          <version>2.0.1</version>
           <executions>
             <execution>
               <goals>
@@ -147,7 +147,7 @@ Rewrites compiled class files to add `@CoverageGenerated` annotations to methods
 <plugin>
     <groupId>io.github.moranaapps</groupId>
     <artifactId>jacoco-method-filter-maven-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <executions>
         <execution>
             <goals>
@@ -164,7 +164,7 @@ Rewrites compiled class files to add `@CoverageGenerated` annotations to methods
 <plugin>
     <groupId>io.github.moranaapps</groupId>
     <artifactId>jacoco-method-filter-maven-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <configuration>
         <globalRules>https://example.com/team-rules.txt</globalRules>
         <localRules>${project.basedir}/jmf-rules.txt</localRules>
@@ -240,7 +240,7 @@ Generates JaCoCo coverage reports (HTML, XML, CSV) using filtered classes.
 <plugin>
     <groupId>io.github.moranaapps</groupId>
     <artifactId>jacoco-method-filter-maven-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <executions>
         <execution>
             <id>report</id>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.moranaapps</groupId>
     <artifactId>jacoco-method-filter-maven-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>JaCoCo Method Filter Maven Plugin</name>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.github.moranaapps</groupId>
             <artifactId>jacoco-method-filter-core_2.12</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
         </dependency>
 
         <dependency>

--- a/sbt-plugin/README.md
+++ b/sbt-plugin/README.md
@@ -35,7 +35,7 @@ The plugin executes the coverage flow by:
 Add to `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.0")
+addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.1")
 ```
 
 Enable the plugin in your `build.sbt`:

--- a/sbt-plugin/src/main/scala/morana/coverage/JacocoFilterPlugin.scala
+++ b/sbt-plugin/src/main/scala/morana/coverage/JacocoFilterPlugin.scala
@@ -106,7 +106,7 @@ object JacocoFilterPlugin extends AutoPlugin {
 
     // ---- defaults + coordinates
     jacocoVersion := "0.8.14",
-    jmfCoreVersion := "2.0.0",
+    jmfCoreVersion := "2.0.1",
     libraryDependencies ++= Seq(
       ("org.jacoco" % "org.jacoco.agent" % jacocoVersion.value % Test).classifier("runtime"),
       ("org.jacoco" % "org.jacoco.cli" % jacocoVersion.value % Test).classifier("nodeps"),


### PR DESCRIPTION
Bump version to 2.0.1 and update release workflow to cross-publish core library for all Scala versions (2.11, 2.12, 2.13)
