### PR TITLE
Initial code vewrsion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ See plugin documentation for rules file location, dry-run mode, report file expo
 ### Report File Export
 
 Add `--report-file <path>` (and optionally `--report-format txt|json|csv`) to any `--verify` or `--dry-run` invocation
- to save filtered-method results to a file. This is useful for CI traceability and downstream automation. The file
-  content mirrors console output; JSON and CSV formats are also available for machine-readable consumption.
+to save filtered-method results to a file. This is useful for CI traceability and downstream automation. The file
+content mirrors console output; JSON and CSV formats are also available for machine-readable consumption.
 
 | Integration | Setting / Property |
 |-------------|-------------------|

--- a/README.md
+++ b/README.md
@@ -141,14 +141,17 @@ See plugin READMEs for full defaults and customization options.
 
 ### Customization
 
-See plugin documentation for rules file location, dry-run mode, report file export, and behavior when JaCoCo execution data is missing:
+See plugin documentation for rules file location, dry-run mode, report file export, and behavior when JaCoCo execution
+ data is missing:
 
 - [`sbt-plugin/README.md`](./sbt-plugin/README.md)
 - [`maven-plugin/README.md`](./maven-plugin/README.md)
 
 ### Report File Export
 
-Add `--report-file <path>` (and optionally `--report-format txt|json|csv`) to any `--verify` or `--dry-run` invocation to save filtered-method results to a file. This is useful for CI traceability and downstream automation. The file content mirrors console output; JSON and CSV formats are also available for machine-readable consumption.
+Add `--report-file <path>` (and optionally `--report-format txt|json|csv`) to any `--verify` or `--dry-run` invocation
+ to save filtered-method results to a file. This is useful for CI traceability and downstream automation. The file
+  content mirrors console output; JSON and CSV formats are also available for machine-readable consumption.
 
 | Integration | Setting / Property |
 |-------------|-------------------|

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ See plugin documentation for rules file location, dry-run mode, report file expo
 
 ### Report File Export
 
-Add `--report-file <path>` (and optionally `--report-format txt|json|csv`) to any `--verify` or `--dry-run` invocation
+Add `--report-file <path>` (and optionally `--report-format txt|json|csv`) to any rewrite, `--verify`, or `--dry-run` invocation
 to save filtered-method results to a file. This is useful for CI traceability and downstream automation. The file
 content mirrors console output; JSON and CSV formats are also available for machine-readable consumption.
 

--- a/README.md
+++ b/README.md
@@ -141,10 +141,20 @@ See plugin READMEs for full defaults and customization options.
 
 ### Customization
 
-See plugin documentation for rules file location, dry-run mode, and behavior when JaCoCo execution data is missing:
+See plugin documentation for rules file location, dry-run mode, report file export, and behavior when JaCoCo execution data is missing:
 
 - [`sbt-plugin/README.md`](./sbt-plugin/README.md)
 - [`maven-plugin/README.md`](./maven-plugin/README.md)
+
+### Report File Export
+
+Add `--report-file <path>` (and optionally `--report-format txt|json|csv`) to any `--verify` or `--dry-run` invocation to save filtered-method results to a file. This is useful for CI traceability and downstream automation. The file content mirrors console output; JSON and CSV formats are also available for machine-readable consumption.
+
+| Integration | Setting / Property |
+|-------------|-------------------|
+| CLI         | `--report-file <path>`, `--report-format txt\|json\|csv` |
+| sbt         | `jmfReportFile := Some(...)`, `jmfReportFormat := "json"` |
+| Maven       | `-Djmf.reportFile=<path>`, `-Djmf.reportFormat=json` |
 
 ---
 

--- a/integration-tests/test-cli-report-file.sh
+++ b/integration-tests/test-cli-report-file.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Test: CLI --report-file and --report-format flags.
+#
+# Verifies:
+# - --verify --report-file writes a txt report to disk
+# - --verify --report-file --report-format json writes JSON
+# - --verify --report-file --report-format csv writes CSV with correct header
+# - --dry-run --report-file writes a report after a dry-run rewrite pass
+# - --report-file with nested (non-existent) parent directory creates dirs
+#
+# Prerequisite: rewriter-core published locally.
+# ---------------------------------------------------------------------------
+source "$(dirname "$0")/helpers.sh"
+
+TEST_NAME="cli-report-file"
+info "Running: $TEST_NAME"
+
+# Set up project
+cp -R "$REPO_ROOT/integration-tests/fixtures/sbt-basic" "$WORK_DIR/project"
+cp -R "$REPO_ROOT/examples/sbt-basic/src"               "$WORK_DIR/project/src"
+cp    "$REPO_ROOT/examples/sbt-basic/jmf-rules.txt"     "$WORK_DIR/project/"
+cd "$WORK_DIR/project"
+
+# Compile to produce .class files and seed Coursier cache
+run_cmd "$TEST_NAME — compiling project" sbt compile
+run_cmd "$TEST_NAME — exporting classpath" sbt "export runtime:dependencyClasspath"
+
+assert_dir_not_empty "target/scala-2.12/classes" \
+  "$TEST_NAME — compiled classes exist"
+
+# ── Build CLI classpath ────────────────────────────────────────────────────
+CORE_JAR=$(
+  find ~/.ivy2/local/io.github.moranaapps/jacoco-method-filter-core_2.12 \
+    -name "jacoco-method-filter-core_2.12.jar" 2>/dev/null | \
+  while IFS= read -r f; do
+    timestamp=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null)
+    printf '%s\t%s\n' "$timestamp" "$f"
+  done | \
+  sort -rn | head -1 | cut -f2- || true
+)
+SCALA_LIB=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "scala-library-2.12*.jar" 2>/dev/null | head -1 || true)
+ASM_JAR=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "asm-9.*.jar" 2>/dev/null | sort -V | tail -1 || true)
+ASM_COMMONS_JAR=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "asm-commons-9.*.jar" 2>/dev/null | sort -V | tail -1 || true)
+SCOPT_JAR=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "scopt_2.12-*.jar" 2>/dev/null | head -1 || true)
+
+[[ -n "$CORE_JAR"  && -f "$CORE_JAR"  ]] || fail "$TEST_NAME — core JAR not found (run 'sbt publishLocal' first)"
+[[ -n "$SCALA_LIB" && -f "$SCALA_LIB" ]] || fail "$TEST_NAME — Scala library not found in Coursier cache"
+[[ -n "$ASM_JAR"   && -f "$ASM_JAR"   ]] || fail "$TEST_NAME — ASM JAR not found in Coursier cache"
+[[ -n "$SCOPT_JAR" && -f "$SCOPT_JAR" ]] || fail "$TEST_NAME — scopt JAR not found in Coursier cache"
+
+CP="$CORE_JAR:$SCALA_LIB:$ASM_JAR:$SCOPT_JAR"
+[[ -n "$ASM_COMMONS_JAR" && -f "$ASM_COMMONS_JAR" ]] && CP="$CP:$ASM_COMMONS_JAR"
+
+CLI="java -cp $CP io.moranaapps.jacocomethodfilter.CoverageRewriter"
+IN="target/scala-2.12/classes"
+RULES="jmf-rules.txt"
+
+# ── 1. --verify --report-file txt (default format) ────────────────────────
+REPORT_TXT="$WORK_DIR/report-verify.txt"
+info "$TEST_NAME — running CLI verify with --report-file (txt)"
+$CLI --verify --in "$IN" --local-rules "$RULES" --report-file "$REPORT_TXT"
+
+assert_file_exists "$REPORT_TXT" \
+  "$TEST_NAME — txt report file created"
+
+assert_file_contains "$REPORT_TXT" "EXCLUDED" \
+  "$TEST_NAME — txt report contains EXCLUDED section"
+
+assert_file_contains "$REPORT_TXT" "Summary:" \
+  "$TEST_NAME — txt report contains Summary line"
+
+assert_file_contains "$REPORT_TXT" "example.Calculator" \
+  "$TEST_NAME — txt report mentions Calculator (has matched methods)"
+
+# No [verify] prefix in file output (that's stdout-only prefix)
+if grep -q "\[verify\]" "$REPORT_TXT"; then
+  fail "$TEST_NAME — txt report should not contain [verify] prefix"
+fi
+
+pass "$TEST_NAME — txt report file written correctly"
+
+# ── 2. --verify --report-file --report-format json ────────────────────────
+REPORT_JSON="$WORK_DIR/report-verify.json"
+info "$TEST_NAME — running CLI verify with --report-file (json)"
+$CLI --verify --in "$IN" --local-rules "$RULES" \
+  --report-file "$REPORT_JSON" --report-format json
+
+assert_file_exists "$REPORT_JSON" \
+  "$TEST_NAME — json report file created"
+
+assert_file_contains "$REPORT_JSON" '"classesScanned"' \
+  "$TEST_NAME — json report has classesScanned key"
+
+assert_file_contains "$REPORT_JSON" '"excluded"' \
+  "$TEST_NAME — json report has excluded key"
+
+assert_file_contains "$REPORT_JSON" '"rescued"' \
+  "$TEST_NAME — json report has rescued key"
+
+# Must be parseable as JSON (at minimum: starts with { ends with })
+head -1 "$REPORT_JSON" | grep -q "^{" || \
+  fail "$TEST_NAME — json report does not start with {"
+
+pass "$TEST_NAME — json report file written correctly"
+
+# ── 3. --verify --report-file --report-format csv ────────────────────────
+REPORT_CSV="$WORK_DIR/report-verify.csv"
+info "$TEST_NAME — running CLI verify with --report-file (csv)"
+$CLI --verify --in "$IN" --local-rules "$RULES" \
+  --report-file "$REPORT_CSV" --report-format csv
+
+assert_file_exists "$REPORT_CSV" \
+  "$TEST_NAME — csv report file created"
+
+assert_file_contains "$REPORT_CSV" \
+  "outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds" \
+  "$TEST_NAME — csv report has correct header"
+
+assert_file_contains "$REPORT_CSV" "EXCLUDED" \
+  "$TEST_NAME — csv report contains EXCLUDED rows"
+
+pass "$TEST_NAME — csv report file written correctly"
+
+# ── 4. --dry-run --report-file ────────────────────────────────────────────
+REPORT_DRYRUN="$WORK_DIR/report-dryrun.txt"
+OUT_DIR="$WORK_DIR/classes-filtered"
+info "$TEST_NAME — running CLI dry-run with --report-file"
+$CLI --dry-run --in "$IN" --out "$OUT_DIR" --local-rules "$RULES" \
+  --report-file "$REPORT_DRYRUN"
+
+assert_file_exists "$REPORT_DRYRUN" \
+  "$TEST_NAME — dry-run report file created"
+
+assert_file_contains "$REPORT_DRYRUN" "EXCLUDED" \
+  "$TEST_NAME — dry-run report contains EXCLUDED section"
+
+pass "$TEST_NAME — dry-run report file written correctly"
+
+# ── 5. --report-file in nested (non-existent) directory ───────────────────
+NESTED_REPORT="$WORK_DIR/nested/deep/path/report.json"
+info "$TEST_NAME — running CLI verify with nested report path"
+$CLI --verify --in "$IN" --local-rules "$RULES" \
+  --report-file "$NESTED_REPORT" --report-format json
+
+assert_file_exists "$NESTED_REPORT" \
+  "$TEST_NAME — report file created in nested directory"
+
+pass "$TEST_NAME — nested parent directory created automatically"
+
+pass "$TEST_NAME"

--- a/integration-tests/test-cli-report-file.sh
+++ b/integration-tests/test-cli-report-file.sh
@@ -148,4 +148,12 @@ assert_file_exists "$NESTED_REPORT" \
 
 pass "$TEST_NAME — nested parent directory created automatically"
 
+# ── 6. --report-format without --report-file is rejected ─────────────────
+info "$TEST_NAME — verifying --report-format without --report-file is rejected"
+if $CLI --verify --in "$IN" --local-rules "$RULES" --report-format json > /dev/null 2>&1; then
+  fail "$TEST_NAME — CLI must reject --report-format without --report-file"
+fi
+
+pass "$TEST_NAME — --report-format without --report-file rejected correctly"
+
 pass "$TEST_NAME"

--- a/integration-tests/test-sbt-report-file.sh
+++ b/integration-tests/test-sbt-report-file.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Test: sbt jmfVerify with jmfReportFile + jmfReportFormat settings.
+#
+# Verifies that the sbt plugin writes the filtered-methods report to a file
+# in all three supported formats (txt, json, csv) and that each file's
+# content is structurally correct.
+#
+# Rules file used here deliberately exercises all three rule kinds so every
+# section of each report format is exercised:
+#   - Global rules  (*#copy(*) etc.)   → EXCLUDED via scala-* rule IDs
+#   - Local rule    (class-specific)   → EXCLUDED via local-calc-add rule ID
+#   - Include rule  (+… rescue)        → RESCUED via rescue-calc-tostring rule ID
+#
+# Prerequisite: sbt plugin published locally.
+# ---------------------------------------------------------------------------
+source "$(dirname "$0")/helpers.sh"
+
+TEST_NAME="sbt-report-file"
+info "Running: $TEST_NAME"
+
+cp -R "$REPO_ROOT/integration-tests/fixtures/sbt-basic" "$WORK_DIR/project"
+cp -R "$REPO_ROOT/examples/sbt-basic/src"               "$WORK_DIR/project/src"
+
+# Custom rules file: global + local + include — written directly into work dir
+# so assertions can check all three rule kinds appear in report output.
+cat > "$WORK_DIR/project/jmf-rules.txt" << 'RULES'
+# [jmf:1.0.0]
+
+# ── Global rules (match any class) ───────────────────────────────────────────
+*#copy(*)                               id:scala-copy
+*#copy$default$*(*)                     id:scala-copy-default
+*#productArity(*)                       id:scala-product-arity
+*#productElement(*)                     id:scala-product-element
+*#productPrefix(*)                      id:scala-product-prefix
+*#productIterator(*)                    id:scala-product-iterator
+*#equals(*)                             id:scala-equals
+*#hashCode(*)                           id:scala-hashcode
+*#toString(*)                           id:scala-tostring
+*#canEqual(*)                           id:scala-canequal
+
+# ── Local rule (class-specific: exclude Calculator#add) ──────────────────────
+example.Calculator#add(*)               id:local-calc-add
+
+# ── Include rule (rescue Calculator#toString from global exclusion) ───────────
++example.Calculator#toString(*)         id:rescue-calc-tostring
+RULES
+
+cd "$WORK_DIR/project"
+
+# ── 1. txt format ──────────────────────────────────────────────────────────
+REPORT_TXT="$WORK_DIR/jmf-report.txt"
+
+info "$TEST_NAME — running jmfVerify with txt report"
+LOG="$WORK_DIR/jmfVerify-txt.log"
+if ! sbt \
+  "set jmfReportFile := Some(file(\"$REPORT_TXT\"))" \
+  "set jmfReportFormat := \"txt\"" \
+  jmfVerify > "$LOG" 2>&1; then
+  cat "$LOG"
+  fail "$TEST_NAME — sbt jmfVerify (txt) failed"
+fi
+
+assert_file_exists "$REPORT_TXT" \
+  "$TEST_NAME — txt report file created"
+
+# EXCLUDED section — Calculator boilerplate via global rules + local rule
+assert_file_contains "$REPORT_TXT" "EXCLUDED" \
+  "$TEST_NAME — txt report contains EXCLUDED section"
+
+assert_file_contains "$REPORT_TXT" "example.Calculator" \
+  "$TEST_NAME — txt report mentions Calculator"
+
+# Global rule ID visible in EXCLUDED section
+assert_file_contains "$REPORT_TXT" "scala-copy" \
+  "$TEST_NAME — txt report contains scala-copy rule ID (global rule)"
+
+# Local rule ID visible in EXCLUDED section (class-specific rule)
+assert_file_contains "$REPORT_TXT" "local-calc-add" \
+  "$TEST_NAME — txt report contains local-calc-add rule ID (local rule)"
+
+# RESCUED section — toString rescued by include rule
+assert_file_contains "$REPORT_TXT" "RESCUED" \
+  "$TEST_NAME — txt report contains RESCUED section"
+
+assert_file_contains "$REPORT_TXT" "rescue-calc-tostring" \
+  "$TEST_NAME — txt report contains rescue-calc-tostring rule ID (include rule)"
+
+assert_file_contains "$REPORT_TXT" "Summary:" \
+  "$TEST_NAME — txt report contains Summary line"
+
+# No [verify] stdout prefix in file
+if grep -q "\[verify\]" "$REPORT_TXT"; then
+  fail "$TEST_NAME — txt report must not contain [verify] prefix"
+fi
+
+pass "$TEST_NAME — txt report file content correct"
+
+# ── 2. json format ─────────────────────────────────────────────────────────
+REPORT_JSON="$WORK_DIR/jmf-report.json"
+
+info "$TEST_NAME — running jmfVerify with json report"
+LOG="$WORK_DIR/jmfVerify-json.log"
+if ! sbt \
+  "set jmfReportFile := Some(file(\"$REPORT_JSON\"))" \
+  "set jmfReportFormat := \"json\"" \
+  jmfVerify > "$LOG" 2>&1; then
+  cat "$LOG"
+  fail "$TEST_NAME — sbt jmfVerify (json) failed"
+fi
+
+assert_file_exists "$REPORT_JSON" \
+  "$TEST_NAME — json report file created"
+
+assert_file_contains "$REPORT_JSON" '"classesScanned"' \
+  "$TEST_NAME — json report has classesScanned key"
+
+assert_file_contains "$REPORT_JSON" '"excluded"' \
+  "$TEST_NAME — json report has excluded key"
+
+assert_file_contains "$REPORT_JSON" '"rescued"' \
+  "$TEST_NAME — json report has rescued key"
+
+assert_file_contains "$REPORT_JSON" '"example.Calculator"' \
+  "$TEST_NAME — json report mentions Calculator"
+
+# File must start with { (well-formed JSON object)
+head -1 "$REPORT_JSON" | grep -q "^{" || \
+  fail "$TEST_NAME — json report does not start with {"
+
+# excluded array non-empty: global rule visible
+assert_file_contains "$REPORT_JSON" '"scala-copy"' \
+  "$TEST_NAME — json excluded entries contain scala-copy (global rule)"
+
+# excluded array: local rule visible
+assert_file_contains "$REPORT_JSON" '"local-calc-add"' \
+  "$TEST_NAME — json excluded entries contain local-calc-add (local rule)"
+
+# rescued array non-empty: include rule visible
+assert_file_contains "$REPORT_JSON" '"rescue-calc-tostring"' \
+  "$TEST_NAME — json rescued entries contain rescue-calc-tostring (include rule)"
+
+# rescued entries have both exclusionRuleIds and inclusionRuleIds keys
+assert_file_contains "$REPORT_JSON" '"exclusionRuleIds"' \
+  "$TEST_NAME — json rescued entries have exclusionRuleIds key"
+
+assert_file_contains "$REPORT_JSON" '"inclusionRuleIds"' \
+  "$TEST_NAME — json rescued entries have inclusionRuleIds key"
+
+pass "$TEST_NAME — json report file content correct"
+
+# ── 3. csv format ──────────────────────────────────────────────────────────
+REPORT_CSV="$WORK_DIR/jmf-report.csv"
+
+info "$TEST_NAME — running jmfVerify with csv report"
+LOG="$WORK_DIR/jmfVerify-csv.log"
+if ! sbt \
+  "set jmfReportFile := Some(file(\"$REPORT_CSV\"))" \
+  "set jmfReportFormat := \"csv\"" \
+  jmfVerify > "$LOG" 2>&1; then
+  cat "$LOG"
+  fail "$TEST_NAME — sbt jmfVerify (csv) failed"
+fi
+
+assert_file_exists "$REPORT_CSV" \
+  "$TEST_NAME — csv report file created"
+
+# Header row must be exact
+HEADER="outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds"
+assert_file_contains "$REPORT_CSV" "$HEADER" \
+  "$TEST_NAME — csv report has correct header"
+
+assert_file_contains "$REPORT_CSV" "EXCLUDED" \
+  "$TEST_NAME — csv report contains EXCLUDED rows"
+
+assert_file_contains "$REPORT_CSV" "example.Calculator" \
+  "$TEST_NAME — csv report mentions Calculator"
+
+# Global rule ID in EXCLUDED rows
+assert_file_contains "$REPORT_CSV" "scala-copy" \
+  "$TEST_NAME — csv EXCLUDED rows contain scala-copy (global rule)"
+
+# Local rule ID in EXCLUDED rows
+assert_file_contains "$REPORT_CSV" "local-calc-add" \
+  "$TEST_NAME — csv EXCLUDED rows contain local-calc-add (local rule)"
+
+# RESCUED row present — include rule in action
+assert_file_contains "$REPORT_CSV" "RESCUED" \
+  "$TEST_NAME — csv report contains RESCUED row"
+
+assert_file_contains "$REPORT_CSV" "rescue-calc-tostring" \
+  "$TEST_NAME — csv RESCUED row contains rescue-calc-tostring (include rule)"
+
+# RESCUED row must also show the exclusion rule that was overridden
+assert_file_contains "$REPORT_CSV" "scala-tostring" \
+  "$TEST_NAME — csv RESCUED row shows exclusionRuleId scala-tostring"
+
+# Every data row (non-header) must have 6 comma-separated fields
+INVALID_ROWS=$(tail -n +2 "$REPORT_CSV" | awk -F',' 'NF != 6 { print NR+1": "$0 }')
+if [[ -n "$INVALID_ROWS" ]]; then
+  echo "Rows with wrong field count:"
+  echo "$INVALID_ROWS"
+  fail "$TEST_NAME — csv report has rows with wrong number of fields"
+fi
+
+pass "$TEST_NAME — csv report file content correct"
+
+# ── 4. No report file written when jmfReportFile is None (default) ─────────
+info "$TEST_NAME — verifying no report file written when jmfReportFile = None"
+DEFAULT_OUT="$WORK_DIR/should-not-exist.txt"
+sbt jmfVerify > /dev/null 2>&1 || true
+if [[ -f "$DEFAULT_OUT" ]]; then
+  fail "$TEST_NAME — report file should not be written when jmfReportFile = None"
+fi
+
+pass "$TEST_NAME — no report file written by default"
+
+pass "$TEST_NAME"

--- a/integration-tests/test-sbt-report-file.sh
+++ b/integration-tests/test-sbt-report-file.sh
@@ -147,6 +147,11 @@ assert_file_contains "$REPORT_JSON" '"exclusionRuleIds"' \
 assert_file_contains "$REPORT_JSON" '"inclusionRuleIds"' \
   "$TEST_NAME — json rescued entries have inclusionRuleIds key"
 
+# excluded entries must also use exclusionRuleIds (not legacy ruleIds)
+if grep -q '"ruleIds"' "$REPORT_JSON"; then
+  fail "$TEST_NAME — json report must not use legacy 'ruleIds' key; expected 'exclusionRuleIds'"
+fi
+
 pass "$TEST_NAME — json report file content correct"
 
 # ── 3. csv format ──────────────────────────────────────────────────────────

--- a/integration-tests/test-sbt-report-file.sh
+++ b/integration-tests/test-sbt-report-file.sh
@@ -206,11 +206,14 @@ fi
 pass "$TEST_NAME — csv report file content correct"
 
 # ── 4. No report file written when jmfReportFile is None (default) ─────────
+# Run jmfVerify without any jmfReportFile setting (default = None).
+# The sbt output must NOT contain "[info] Report written to:" because no
+# report file path is configured.
 info "$TEST_NAME — verifying no report file written when jmfReportFile = None"
-DEFAULT_OUT="$WORK_DIR/should-not-exist.txt"
-sbt jmfVerify > /dev/null 2>&1 || true
-if [[ -f "$DEFAULT_OUT" ]]; then
-  fail "$TEST_NAME — report file should not be written when jmfReportFile = None"
+DEFAULT_LOG="$WORK_DIR/jmfVerify-default.log"
+sbt jmfVerify > "$DEFAULT_LOG" 2>&1 || true
+if grep -q "Report written to" "$DEFAULT_LOG"; then
+  fail "$TEST_NAME — report file must not be written when jmfReportFile = None"
 fi
 
 pass "$TEST_NAME — no report file written by default"

--- a/maven-plugin/README.md
+++ b/maven-plugin/README.md
@@ -135,6 +135,8 @@ Rewrites compiled class files to add `@CoverageGenerated` annotations to methods
 | `jmf.inputDirectory` | `File` | `${project.build.outputDirectory}` | Input classes directory. |
 | `jmf.outputDirectory` | `File` | `${project.build.directory}/classes-filtered` | Output classes directory. |
 | `jmf.dryRun` | `boolean` | `false` | Dry run mode — no files modified. |
+| `jmf.reportFile` | `File` | — | Write filtered-methods report to this file. Useful with `dryRun=true` or the `verify` goal. If not set, output goes to console only. |
+| `jmf.reportFormat` | `String` | `"txt"` | Report format: `txt` (plain text), `json`, or `csv`. Only used when `reportFile` is set. |
 | `jmf.skip` | `boolean` | `false` | Skip execution. |
 
 > **Note:** `globalRules` and `localRules` can be used together; global rules are loaded first,
@@ -190,12 +192,20 @@ Scans compiled classes and reports which methods would be matched by the configu
 | `jmf.globalRules` | `String` | — | Global rules source (path or URL). Can be combined with `localRules`. |
 | `jmf.localRules` | `File` | `${project.basedir}/jmf-rules.txt` | Local rules file. Can be combined with `globalRules`. |
 | `jmf.inputDirectory` | `File` | `${project.build.outputDirectory}` | Input classes directory. |
+| `jmf.reportFile` | `File` | — | Write filtered-methods report to this file. If not set, output goes to console only. |
+| `jmf.reportFormat` | `String` | `"txt"` | Report format: `txt` (plain text), `json`, or `csv`. Only used when `reportFile` is set. |
 | `jmf.skip` | `boolean` | `false` | Skip execution. |
 
 **Example:**
 
 ```bash
 mvn compile jacoco-method-filter:verify
+```
+
+**Example with report file export:**
+
+```bash
+mvn compile jacoco-method-filter:verify -Djmf.reportFile=target/jmf-report.json -Djmf.reportFormat=json
 ```
 
 ### `jacoco-method-filter:report`

--- a/maven-plugin/src/main/java/io/moranaapps/mavenplugin/RewriteMojo.java
+++ b/maven-plugin/src/main/java/io/moranaapps/mavenplugin/RewriteMojo.java
@@ -39,6 +39,12 @@ public class RewriteMojo extends AbstractMojo {
     @Parameter(property = "jmf.dryRun", defaultValue = "false")
     private boolean dryRun;
 
+    @Parameter(property = "jmf.reportFile")
+    private File reportFile;
+
+    @Parameter(property = "jmf.reportFormat", defaultValue = "txt")
+    private String reportFormat;
+
     @Parameter(property = "jmf.skip", defaultValue = "false")
     private boolean skip;
 
@@ -95,6 +101,9 @@ public class RewriteMojo extends AbstractMojo {
         getLog().info("║ Destination: " + outputDirectory.getAbsolutePath());
         logRulesConfig();
         getLog().info("║ Dry run:     " + (dryRun ? "YES (no writes)" : "NO"));
+        if (reportFile != null) {
+            getLog().info("║ Report:      " + reportFile.getAbsolutePath() + " (" + reportFormat + ")");
+        }
         getLog().info("╚═══════════════════════════════════════════════");
 
         launchSubprocess(command);
@@ -121,6 +130,12 @@ public class RewriteMojo extends AbstractMojo {
         }
         
         if (dryRun) cmd.add("--dry-run");
+        if (reportFile != null) {
+            cmd.add("--report-file");
+            cmd.add(reportFile.getAbsolutePath());
+            cmd.add("--report-format");
+            cmd.add(reportFormat);
+        }
         return cmd;
     }
 

--- a/maven-plugin/src/main/java/io/moranaapps/mavenplugin/VerifyMojo.java
+++ b/maven-plugin/src/main/java/io/moranaapps/mavenplugin/VerifyMojo.java
@@ -31,6 +31,12 @@ public class VerifyMojo extends AbstractMojo {
     @Parameter(property = "jmf.inputDirectory", defaultValue = "${project.build.outputDirectory}")
     private File inputDirectory;
 
+    @Parameter(property = "jmf.reportFile")
+    private File reportFile;
+
+    @Parameter(property = "jmf.reportFormat", defaultValue = "txt")
+    private String reportFormat;
+
     @Parameter(property = "jmf.skip", defaultValue = "false")
     private boolean skip;
 
@@ -85,6 +91,9 @@ public class VerifyMojo extends AbstractMojo {
         getLog().info("╔═══ JaCoCo Method Filter: Verify Rules Impact ═══");
         getLog().info("║ Classes:     " + inputDirectory.getAbsolutePath());
         logRulesConfig();
+        if (reportFile != null) {
+            getLog().info("║ Report:      " + reportFile.getAbsolutePath() + " (" + reportFormat + ")");
+        }
         getLog().info("╚══════════════════════════════════════════════════");
 
         launchSubprocess(command);
@@ -108,7 +117,13 @@ public class VerifyMojo extends AbstractMojo {
             cmd.add("--local-rules");
             cmd.add(localRules.getAbsolutePath());
         }
-        
+        if (reportFile != null) {
+            cmd.add("--report-file");
+            cmd.add(reportFile.getAbsolutePath());
+            cmd.add("--report-format");
+            cmd.add(reportFormat);
+        }
+
         return cmd;
     }
 

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriter.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriter.scala
@@ -63,6 +63,8 @@ object CoverageRewriter {
     println(s"[info] Processed $files class file(s), marked $marked method(s). dry-run=${cfg.dryRun}")
 
     cfg.reportFile.foreach { path =>
+      // TODO(perf): avoid second scan by collecting MatchedMethod data during the rewrite pass above
+      // (each rewriteClassFile call already invokes RuleResolver.resolve per method)
       val result = VerifyScanner.scan(cfg.in, rules)
       writeReportFile(path, result.formatReport(cfg.reportFormat))
     }

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriter.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriter.scala
@@ -13,6 +13,8 @@ import java.nio.file.{Files, Path, Paths}
   * @param localRules Local rules file path (optional if globalRules provided)
   * @param dryRun If true, print matches without modifying classes
   * @param verify If true, run read-only scan mode
+  * @param reportFile Optional path to write the filtered-methods report (txt/json/csv)
+  * @param reportFormat Report format: txt (default), json, or csv
   */
 private[jacocomethodfilter] final case class CliConfig(
   in: Path = Paths.get("."),
@@ -20,7 +22,9 @@ private[jacocomethodfilter] final case class CliConfig(
   globalRules: Option[String] = None,
   localRules: Option[Path] = None,
   dryRun: Boolean = false,
-  verify: Boolean = false
+  verify: Boolean = false,
+  reportFile: Option[Path] = None,
+  reportFormat: String = "txt"
 )
 
 object CoverageRewriter {
@@ -57,6 +61,11 @@ object CoverageRewriter {
     }
 
     println(s"[info] Processed $files class file(s), marked $marked method(s). dry-run=${cfg.dryRun}")
+
+    cfg.reportFile.foreach { path =>
+      val result = VerifyScanner.scan(cfg.in, rules)
+      writeReportFile(path, result.formatReport(cfg.reportFormat))
+    }
   }
 
   private def verify(cfg: CliConfig): Unit = {
@@ -69,11 +78,21 @@ object CoverageRewriter {
     result.printReport(println)
 
     println(s"[info] Verification complete: scanned ${result.classesScanned} class file(s), found ${result.totalMatched} method(s) matched by rules.")
+
+    cfg.reportFile.foreach { path =>
+      writeReportFile(path, result.formatReport(cfg.reportFormat))
+    }
   }
 
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
+
+  private def writeReportFile(path: Path, content: String): Unit = {
+    Option(path.getParent).foreach(Files.createDirectories(_))
+    Files.write(path, content.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+    println(s"[info] Report written to: $path")
+  }
 
   /** Human-readable description of the configured rule sources. */
   private def rulesSummary(cfg: CliConfig): String =

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
@@ -66,6 +66,8 @@ private[jacocomethodfilter] object CoverageRewriterCli {
           failure("--out is required when not in verify mode")
         } else if (cfg.globalRules.isEmpty && cfg.localRules.isEmpty) {
           failure("At least one of --global-rules or --local-rules must be specified")
+        } else if (cfg.reportFile.exists(Files.isDirectory(_))) {
+          failure("--report-file must be a file path, not an existing directory")
         } else {
           success
         }

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
@@ -48,13 +48,13 @@ private[jacocomethodfilter] object CoverageRewriterCli {
       opt[String]("report-file")
         .optional()
         .action((v, c) => c.copy(reportFile = Some(Paths.get(v))))
-        .text("Write filtered-methods report to this file (useful with --verify or --dry-run)")
+        .text("Write filtered-methods report to this file (works with --verify, --dry-run, and rewrite)")
 
       opt[String]("report-format")
         .optional()
-        .action((v, c) => c.copy(reportFormat = v))
+        .action((v, c) => c.copy(reportFormat = v.toLowerCase))
         .validate(v =>
-          if (Set("txt", "json", "csv").contains(v)) success
+          if (Set("txt", "json", "csv").contains(v.toLowerCase)) success
           else failure("--report-format must be one of: txt, json, csv")
         )
         .text("Report format: txt (default), json, or csv")

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
@@ -45,6 +45,20 @@ private[jacocomethodfilter] object CoverageRewriterCli {
         .action((_, c) => c.copy(verify = true))
         .text("Read-only scan: list all methods that would be excluded by rules")
 
+      opt[String]("report-file")
+        .optional()
+        .action((v, c) => c.copy(reportFile = Some(Paths.get(v))))
+        .text("Write filtered-methods report to this file (useful with --verify or --dry-run)")
+
+      opt[String]("report-format")
+        .optional()
+        .action((v, c) => c.copy(reportFormat = v))
+        .validate(v =>
+          if (Set("txt", "json", "csv").contains(v)) success
+          else failure("--report-format must be one of: txt, json, csv")
+        )
+        .text("Report format: txt (default), json, or csv")
+
       checkConfig { cfg =>
         if (!Files.isDirectory(cfg.in)) {
           failure("--in must exist and be a directory")

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
@@ -68,6 +68,8 @@ private[jacocomethodfilter] object CoverageRewriterCli {
           failure("At least one of --global-rules or --local-rules must be specified")
         } else if (cfg.reportFile.exists(Files.isDirectory(_))) {
           failure("--report-file must be a file path, not an existing directory")
+        } else if (cfg.reportFile.isEmpty && cfg.reportFormat != "txt") {
+          failure("--report-format requires --report-file to be set")
         } else {
           success
         }

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
@@ -28,6 +28,11 @@ final case class ScanResult(
   def excludedMethods: Seq[MatchedMethod] = matches.filter(_.outcome == Excluded)
   def rescuedMethods: Seq[MatchedMethod] = matches.filter(_.outcome == Rescued)
 
+  private def plural(n: Int, word: String): String = {
+    val pluralForm = if (word == "class") "classes" else word + "s"
+    if (n == 1) s"$n $word" else s"$n $pluralForm"
+  }
+
   /** Print report to stdout. */
   def printReport(): Unit = printReport(println)
 
@@ -35,7 +40,7 @@ final case class ScanResult(
   def printReport(out: String => Unit): Unit = {
     val excluded = excludedMethods
     if (excluded.nonEmpty) {
-      out(s"[verify] EXCLUDED (${excluded.size} methods):")
+      out(s"[verify] EXCLUDED (${plural(excluded.size, "method")}):")
       val byClass = excluded.groupBy(_.fqcn).toSeq.sortBy(_._1)
       byClass.foreach { case (fqcn, methods) =>
         out(s"[verify]   $fqcn")
@@ -53,7 +58,7 @@ final case class ScanResult(
 
     val rescued = rescuedMethods
     if (rescued.nonEmpty) {
-      out(s"[verify] RESCUED by include rules (${rescued.size} methods):")
+      out(s"[verify] RESCUED by include rules (${plural(rescued.size, "method")}):")
       val byClass = rescued.groupBy(_.fqcn).toSeq.sortBy(_._1)
       byClass.foreach { case (fqcn, methods) =>
         out(s"[verify]   $fqcn")
@@ -66,7 +71,7 @@ final case class ScanResult(
       out("")
     }
 
-    out(s"[verify] Summary: $classesScanned classes scanned, ${excluded.size} methods excluded, ${rescued.size} methods rescued")
+    out(s"[verify] Summary: ${plural(classesScanned, "class")} scanned, ${plural(excluded.size, "method")} excluded, ${plural(rescued.size, "method")} rescued")
   }
 
   /** Format the report as a string in the specified format: txt (default), json, or csv. */
@@ -81,7 +86,7 @@ final case class ScanResult(
     val rescued  = rescuedMethods
     val lines    = scala.collection.mutable.ArrayBuffer.empty[String]
     if (excluded.nonEmpty) {
-      lines += s"EXCLUDED (${excluded.size} methods):"
+      lines += s"EXCLUDED (${plural(excluded.size, "method")}):"
       excluded.groupBy(_.fqcn).toSeq.sortBy(_._1).foreach { case (fqcn, methods) =>
         lines += s"  $fqcn"
         methods.sortBy(m => (m.methodName, m.descriptor)).foreach { m =>
@@ -92,7 +97,7 @@ final case class ScanResult(
       lines += ""
     }
     if (rescued.nonEmpty) {
-      lines += s"RESCUED by include rules (${rescued.size} methods):"
+      lines += s"RESCUED by include rules (${plural(rescued.size, "method")}):"
       rescued.groupBy(_.fqcn).toSeq.sortBy(_._1).foreach { case (fqcn, methods) =>
         lines += s"  $fqcn"
         methods.sortBy(m => (m.methodName, m.descriptor)).foreach { m =>
@@ -103,7 +108,7 @@ final case class ScanResult(
       }
       lines += ""
     }
-    lines += s"Summary: $classesScanned classes scanned, ${excluded.size} methods excluded, ${rescued.size} methods rescued"
+    lines += s"Summary: ${plural(classesScanned, "class")} scanned, ${plural(excluded.size, "method")} excluded, ${plural(rescued.size, "method")} rescued"
     lines.mkString("\n")
   }
 

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
@@ -112,8 +112,8 @@ final case class ScanResult(
     def str(s: String): String = s""""${esc(s)}""""
     def strArr(seq: Seq[String]): String = seq.map(str).mkString("[", ", ", "]")
 
-    val excluded = excludedMethods
-    val rescued  = rescuedMethods
+    val excluded = excludedMethods.sortBy(m => (m.fqcn, m.methodName, m.descriptor))
+    val rescued  = rescuedMethods.sortBy(m => (m.fqcn, m.methodName, m.descriptor))
 
     def excludedEntry(m: MatchedMethod): String =
       s"""    {"class": ${str(m.fqcn)}, "method": ${str(m.methodName)}, "descriptor": ${str(m.descriptor)}, "ruleIds": ${strArr(m.exclusionIds)}}"""
@@ -135,8 +135,8 @@ final case class ScanResult(
     def cell(s: String): String =
       if (s.exists(c => c == ',' || c == '"' || c == '\n')) s""""${s.replace("\"", "\"\"")}"""" else s
 
-    val excluded = excludedMethods
-    val rescued  = rescuedMethods
+    val excluded = excludedMethods.sortBy(m => (m.fqcn, m.methodName, m.descriptor))
+    val rescued  = rescuedMethods.sortBy(m => (m.fqcn, m.methodName, m.descriptor))
     val sb       = new StringBuilder
     sb.append("outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds\n")
     excluded.foreach { m =>

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
@@ -27,13 +27,12 @@ final case class ScanResult(
                             ) {
   def excludedMethods: Seq[MatchedMethod] = matches.filter(_.outcome == Excluded)
   def rescuedMethods: Seq[MatchedMethod] = matches.filter(_.outcome == Rescued)
-  
+
   /** Print report to stdout. */
   def printReport(): Unit = printReport(println)
 
   /** Print a report of matched methods. */
   def printReport(out: String => Unit): Unit = {
-    // Print excluded methods
     val excluded = excludedMethods
     if (excluded.nonEmpty) {
       out(s"[verify] EXCLUDED (${excluded.size} methods):")
@@ -51,8 +50,7 @@ final case class ScanResult(
       }
       out("")
     }
-    
-    // Print rescued methods
+
     val rescued = rescuedMethods
     if (rescued.nonEmpty) {
       out(s"[verify] RESCUED by include rules (${rescued.size} methods):")
@@ -67,8 +65,87 @@ final case class ScanResult(
       }
       out("")
     }
-    
+
     out(s"[verify] Summary: $classesScanned classes scanned, ${excluded.size} methods excluded, ${rescued.size} methods rescued")
+  }
+
+  /** Format the report as a string in the specified format: txt (default), json, or csv. */
+  def formatReport(format: String): String = format.toLowerCase match {
+    case "json" => formatJson()
+    case "csv"  => formatCsv()
+    case _      => formatTxt()
+  }
+
+  private def formatTxt(): String = {
+    val excluded = excludedMethods
+    val rescued  = rescuedMethods
+    val lines    = scala.collection.mutable.ArrayBuffer.empty[String]
+    if (excluded.nonEmpty) {
+      lines += s"EXCLUDED (${excluded.size} methods):"
+      excluded.groupBy(_.fqcn).toSeq.sortBy(_._1).foreach { case (fqcn, methods) =>
+        lines += s"  $fqcn"
+        methods.sortBy(m => (m.methodName, m.descriptor)).foreach { m =>
+          val ruleIdStr = if (m.exclusionIds.nonEmpty) s"  rule-id:${m.exclusionIds.mkString(",")}" else ""
+          lines += s"    #${m.methodName}${m.descriptor}$ruleIdStr"
+        }
+      }
+      lines += ""
+    }
+    if (rescued.nonEmpty) {
+      lines += s"RESCUED by include rules (${rescued.size} methods):"
+      rescued.groupBy(_.fqcn).toSeq.sortBy(_._1).foreach { case (fqcn, methods) =>
+        lines += s"  $fqcn"
+        methods.sortBy(m => (m.methodName, m.descriptor)).foreach { m =>
+          val exclStr = if (m.exclusionIds.nonEmpty) m.exclusionIds.mkString(",") else "(no-id)"
+          val inclStr = if (m.inclusionIds.nonEmpty) m.inclusionIds.mkString(",") else "(no-id)"
+          lines += s"    #${m.methodName}${m.descriptor}  excl:$exclStr \u2192 incl:$inclStr"
+        }
+      }
+      lines += ""
+    }
+    lines += s"Summary: $classesScanned classes scanned, ${excluded.size} methods excluded, ${rescued.size} methods rescued"
+    lines.mkString("\n")
+  }
+
+  private def formatJson(): String = {
+    def esc(s: String): String = s.replace("\\", "\\\\").replace("\"", "\\\"")
+    def str(s: String): String = s""""${esc(s)}""""
+    def strArr(seq: Seq[String]): String = seq.map(str).mkString("[", ", ", "]")
+
+    val excluded = excludedMethods
+    val rescued  = rescuedMethods
+
+    def excludedEntry(m: MatchedMethod): String =
+      s"""    {"class": ${str(m.fqcn)}, "method": ${str(m.methodName)}, "descriptor": ${str(m.descriptor)}, "ruleIds": ${strArr(m.exclusionIds)}}"""
+
+    def rescuedEntry(m: MatchedMethod): String =
+      s"""    {"class": ${str(m.fqcn)}, "method": ${str(m.methodName)}, "descriptor": ${str(m.descriptor)}, "exclusionRuleIds": ${strArr(m.exclusionIds)}, "inclusionRuleIds": ${strArr(m.inclusionIds)}}"""
+
+    val excBlock = if (excluded.isEmpty) "[]" else s"[\n${excluded.map(excludedEntry).mkString(",\n")}\n  ]"
+    val resBlock = if (rescued.isEmpty)  "[]" else s"[\n${rescued.map(rescuedEntry).mkString(",\n")}\n  ]"
+
+    s"""{
+  "classesScanned": $classesScanned,
+  "excluded": $excBlock,
+  "rescued": $resBlock
+}"""
+  }
+
+  private def formatCsv(): String = {
+    def cell(s: String): String =
+      if (s.exists(c => c == ',' || c == '"' || c == '\n')) s""""${s.replace("\"", "\"\"")}"""" else s
+
+    val excluded = excludedMethods
+    val rescued  = rescuedMethods
+    val sb       = new StringBuilder
+    sb.append("outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds\n")
+    excluded.foreach { m =>
+      sb.append(s"EXCLUDED,${cell(m.fqcn)},${cell(m.methodName)},${cell(m.descriptor)},${cell(m.exclusionIds.mkString("|"))},\n")
+    }
+    rescued.foreach { m =>
+      sb.append(s"RESCUED,${cell(m.fqcn)},${cell(m.methodName)},${cell(m.descriptor)},${cell(m.exclusionIds.mkString("|"))},${cell(m.inclusionIds.mkString("|"))}\n")
+    }
+    sb.toString()
   }
 }
 

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
@@ -74,11 +74,15 @@ final case class ScanResult(
     out(s"[verify] Summary: ${plural(classesScanned, "class")} scanned, ${plural(excluded.size, "method")} excluded, ${plural(rescued.size, "method")} rescued")
   }
 
-  /** Format the report as a string in the specified format: txt (default), json, or csv. */
+  /** Format the report as a string in the specified format: txt, json, or csv.
+    *
+    * @throws IllegalArgumentException if format is not one of: txt, json, csv
+    */
   def formatReport(format: String): String = format.toLowerCase match {
+    case "txt"  => formatTxt()
     case "json" => formatJson()
     case "csv"  => formatCsv()
-    case _      => formatTxt()
+    case other  => throw new IllegalArgumentException(s"Unknown report format: '$other'. Supported: txt, json, csv")
   }
 
   private def formatTxt(): String = {
@@ -113,7 +117,14 @@ final case class ScanResult(
   }
 
   private def formatJson(): String = {
-    def esc(s: String): String = s.replace("\\", "\\\\").replace("\"", "\\\"")
+    def esc(s: String): String = s
+      .replace("\\", "\\\\")
+      .replace("\"", "\\\"")
+      .replace("\n", "\\n")
+      .replace("\r", "\\r")
+      .replace("\t", "\\t")
+      .replace("\b", "\\b")
+      .replace("\f", "\\f")
     def str(s: String): String = s""""${esc(s)}""""
     def strArr(seq: Seq[String]): String = seq.map(str).mkString("[", ", ", "]")
 
@@ -121,7 +132,7 @@ final case class ScanResult(
     val rescued  = rescuedMethods.sortBy(m => (m.fqcn, m.methodName, m.descriptor))
 
     def excludedEntry(m: MatchedMethod): String =
-      s"""    {"class": ${str(m.fqcn)}, "method": ${str(m.methodName)}, "descriptor": ${str(m.descriptor)}, "ruleIds": ${strArr(m.exclusionIds)}}"""
+      s"""    {"class": ${str(m.fqcn)}, "method": ${str(m.methodName)}, "descriptor": ${str(m.descriptor)}, "exclusionRuleIds": ${strArr(m.exclusionIds)}}"""
 
     def rescuedEntry(m: MatchedMethod): String =
       s"""    {"class": ${str(m.fqcn)}, "method": ${str(m.methodName)}, "descriptor": ${str(m.descriptor)}, "exclusionRuleIds": ${strArr(m.exclusionIds)}, "inclusionRuleIds": ${strArr(m.inclusionIds)}}"""

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
@@ -170,4 +170,66 @@ class CoverageRewriterCliSpec extends AnyFunSuite {
     val result = CoverageRewriterCli.parse(Array.empty)
     assert(result.isEmpty)
   }
+
+  test("parse should accept --report-file in verify mode") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--report-file", "/tmp/report.txt")
+    )
+    assert(result.isDefined)
+    assert(result.get.reportFile.contains(Paths.get("/tmp/report.txt")))
+  }
+
+  test("parse should accept --report-format json") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--report-file", "/tmp/report.json", "--report-format", "json")
+    )
+    assert(result.isDefined)
+    assert(result.get.reportFormat == "json")
+  }
+
+  test("parse should accept --report-format csv") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--report-file", "/tmp/report.csv", "--report-format", "csv")
+    )
+    assert(result.isDefined)
+    assert(result.get.reportFormat == "csv")
+  }
+
+  test("parse should reject invalid --report-format value") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--report-file", "/tmp/report.xml", "--report-format", "xml")
+    )
+    assert(result.isEmpty)
+  }
+
+  test("parse should default reportFile to None and reportFormat to txt") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify")
+    )
+    assert(result.isDefined)
+    assert(result.get.reportFile.isEmpty)
+    assert(result.get.reportFormat == "txt")
+  }
+
+  test("parse should accept --report-file with --dry-run") {
+    val inDir  = newTempDir("jmf-in-")
+    val outDir = newTempDir("jmf-out-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--out", outDir.toString, "--global-rules", "rules.txt",
+        "--dry-run", "--report-file", "/tmp/dry-run-report.json", "--report-format", "json")
+    )
+    assert(result.isDefined)
+    assert(result.get.dryRun)
+    assert(result.get.reportFile.contains(Paths.get("/tmp/dry-run-report.json")))
+    assert(result.get.reportFormat == "json")
+  }
 }

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
@@ -191,6 +191,16 @@ class CoverageRewriterCliSpec extends AnyFunSuite {
     assert(result.get.reportFormat == "json")
   }
 
+  test("parse should accept --report-format JSON (case-insensitive)") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--report-file", "/tmp/report.json", "--report-format", "JSON")
+    )
+    assert(result.isDefined)
+    assert(result.get.reportFormat == "json", "format must be normalised to lowercase")
+  }
+
   test("parse should accept --report-format csv") {
     val inDir = newTempDir("jmf-in-")
     val result = CoverageRewriterCli.parse(
@@ -199,6 +209,16 @@ class CoverageRewriterCliSpec extends AnyFunSuite {
     )
     assert(result.isDefined)
     assert(result.get.reportFormat == "csv")
+  }
+
+  test("parse should accept --report-format CSV (case-insensitive)") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--report-file", "/tmp/report.csv", "--report-format", "CSV")
+    )
+    assert(result.isDefined)
+    assert(result.get.reportFormat == "csv", "format must be normalised to lowercase")
   }
 
   test("parse should reject invalid --report-format value") {

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
@@ -262,4 +262,34 @@ class CoverageRewriterCliSpec extends AnyFunSuite {
     )
     assert(result.isEmpty, "--report-file pointing to a directory must be rejected")
   }
+
+  test("parse should reject --report-format without --report-file") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--report-format", "json")
+    )
+    assert(result.isEmpty, "--report-format without --report-file must be rejected")
+  }
+
+  test("parse should accept --report-format txt without --report-file (default no-op)") {
+    // txt is the default; specifying it explicitly without a file path is redundant but not an error
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--report-format", "txt")
+    )
+    assert(result.isDefined, "--report-format txt without --report-file is allowed (no-op)")
+  }
+
+  test("parse should accept --report-format TXT (uppercase) without --report-file (default no-op)") {
+    // uppercase TXT normalises to txt before checkConfig; must be treated same as lowercase txt
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--report-format", "TXT")
+    )
+    assert(result.isDefined, "--report-format TXT without --report-file is allowed (normalised to txt)")
+    assert(result.get.reportFormat == "txt", "TXT must be normalised to lowercase txt")
+  }
 }

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
@@ -252,4 +252,14 @@ class CoverageRewriterCliSpec extends AnyFunSuite {
     assert(result.get.reportFile.contains(Paths.get("/tmp/dry-run-report.json")))
     assert(result.get.reportFormat == "json")
   }
+
+  test("parse should reject --report-file pointing to an existing directory") {
+    val inDir = newTempDir("jmf-in-")
+    val dirAsReport = newTempDir("jmf-report-dir-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--report-file", dirAsReport.toString)
+    )
+    assert(result.isEmpty, "--report-file pointing to a directory must be rejected")
+  }
 }

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
@@ -211,7 +211,7 @@ class VerifyScannerSpec extends AnyFunSuite {
     assert(lines.exists(_.contains("EXCLUDED")))
     assert(lines.exists(_.contains("RESCUED")))
     assert(lines.exists(_.contains("Summary")))
-    assert(lines.exists(_.contains("1 methods excluded, 1 methods rescued")))
+    assert(lines.exists(_.contains("1 method excluded, 1 method rescued")))
   }
 
   test("printReport handles methods with no rule IDs") {
@@ -492,17 +492,6 @@ class VerifyScannerSpec extends AnyFunSuite {
     val row = csv.split("\n").find(_.startsWith("RESCUED")).getOrElse(fail("no RESCUED row"))
     assert(row.contains("excl-1|excl-2"))
     assert(row.contains("incl-1"))
-  }
-
-  test("formatReport csv escapes fields containing commas") {
-    // Descriptors can contain commas in edge cases; verify cell quoting
-    val matches = Seq(
-      MatchedMethod("com.example.Foo", "bar", "(Ljava/util/Map;)V", Excluded, Seq("r,id"), Seq.empty, Opcodes.ACC_PUBLIC)
-    )
-    val result = ScanResult(1, 1, matches)
-    val csv = result.formatReport("csv")
-    // rule ID "r,id" contains a comma → must be quoted in CSV
-    assert(csv.contains("\"r,id\""))
   }
 
   test("formatReport json escapes double-quotes in class names") {

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
@@ -524,6 +524,37 @@ class VerifyScannerSpec extends AnyFunSuite {
     assert(txt.contains("Summary: 5 classes scanned, 0 methods excluded, 0 methods rescued"))
   }
 
+  test("formatReport json entries are sorted by (fqcn, methodName, descriptor) for stable output") {
+    // Provide matches in reverse-sorted order; output must be sorted
+    val matches = Seq(
+      MatchedMethod("com.example.Z", "zMethod", "()V", Excluded, Seq("r1"), Seq.empty, Opcodes.ACC_PUBLIC),
+      MatchedMethod("com.example.A", "mMethod", "()V", Excluded, Seq("r2"), Seq.empty, Opcodes.ACC_PUBLIC),
+      MatchedMethod("com.example.A", "aMethod", "()V", Excluded, Seq("r3"), Seq.empty, Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(3, 3, matches)
+    val json = result.formatReport("json")
+    val aPos = json.indexOf("\"com.example.A\"")
+    val zPos = json.lastIndexOf("\"com.example.Z\"")
+    assert(aPos < zPos, "com.example.A entries must appear before com.example.Z in JSON output")
+    // Within com.example.A: aMethod before mMethod
+    val aMethodPos = json.indexOf("\"aMethod\"")
+    val mMethodPos = json.indexOf("\"mMethod\"")
+    assert(aMethodPos < mMethodPos, "aMethod must appear before mMethod in JSON output")
+  }
+
+  test("formatReport csv rows are sorted by (fqcn, methodName, descriptor) for stable output") {
+    val matches = Seq(
+      MatchedMethod("com.example.Z", "zMethod", "()V", Excluded, Seq("r1"), Seq.empty, Opcodes.ACC_PUBLIC),
+      MatchedMethod("com.example.A", "mMethod", "()V", Excluded, Seq("r2"), Seq.empty, Opcodes.ACC_PUBLIC),
+      MatchedMethod("com.example.A", "aMethod", "()V", Excluded, Seq("r3"), Seq.empty, Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(3, 3, matches)
+    val rows = result.formatReport("csv").split("\n").tail // drop header
+    assert(rows(0).contains("com.example.A") && rows(0).contains("aMethod"), "first data row must be A/aMethod")
+    assert(rows(1).contains("com.example.A") && rows(1).contains("mMethod"), "second data row must be A/mMethod")
+    assert(rows(2).contains("com.example.Z") && rows(2).contains("zMethod"), "third data row must be Z/zMethod")
+  }
+
   // Helper to delete directory recursively
   private def deleteRecursively(path: Path): Unit = {
     if (Files.exists(path)) {

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
@@ -447,6 +447,83 @@ class VerifyScannerSpec extends AnyFunSuite {
     assert(!output.contains("{"))
   }
 
+  test("formatReport is case-insensitive for txt") {
+    val result = ScanResult(1, 0, Seq.empty)
+    val output = result.formatReport("TXT")
+    assert(output.contains("Summary:"))
+  }
+
+  test("formatReport is case-insensitive for json") {
+    val result = ScanResult(1, 0, Seq.empty)
+    val output = result.formatReport("JSON")
+    assert(output.contains("\"classesScanned\""))
+  }
+
+  test("formatReport is case-insensitive for csv") {
+    val result = ScanResult(1, 0, Seq.empty)
+    val output = result.formatReport("CSV")
+    assert(output.contains("outcome,class,method,descriptor"))
+  }
+
+  test("formatReport txt shows multiple rule IDs comma-separated") {
+    val matches = Seq(
+      MatchedMethod("com.example.Foo", "copy", "()V", Excluded, Seq("rule-a", "rule-b", "rule-c"), Seq.empty, Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(1, 1, matches)
+    val txt = result.formatReport("txt")
+    assert(txt.contains("rule-id:rule-a,rule-b,rule-c"))
+  }
+
+  test("formatReport csv multiple exclusion rule IDs are pipe-separated") {
+    val matches = Seq(
+      MatchedMethod("com.example.Foo", "copy", "()V", Excluded, Seq("rule-a", "rule-b"), Seq.empty, Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(1, 1, matches)
+    val csv = result.formatReport("csv")
+    assert(csv.contains("rule-a|rule-b"))
+  }
+
+  test("formatReport csv rescued row has both exclusion and inclusion rule IDs pipe-separated") {
+    val matches = Seq(
+      MatchedMethod("com.example.Bar", "apply", "()V", Rescued, Seq("excl-1", "excl-2"), Seq("incl-1"), Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(1, 1, matches)
+    val csv = result.formatReport("csv")
+    val row = csv.split("\n").find(_.startsWith("RESCUED")).getOrElse(fail("no RESCUED row"))
+    assert(row.contains("excl-1|excl-2"))
+    assert(row.contains("incl-1"))
+  }
+
+  test("formatReport csv escapes fields containing commas") {
+    // Descriptors can contain commas in edge cases; verify cell quoting
+    val matches = Seq(
+      MatchedMethod("com.example.Foo", "bar", "(Ljava/util/Map;)V", Excluded, Seq("r,id"), Seq.empty, Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(1, 1, matches)
+    val csv = result.formatReport("csv")
+    // rule ID "r,id" contains a comma → must be quoted in CSV
+    assert(csv.contains("\"r,id\""))
+  }
+
+  test("formatReport json escapes double-quotes in class names") {
+    val matches = Seq(
+      MatchedMethod("com.example.Foo$\"inner\"", "bar", "()V", Excluded, Seq("r1"), Seq.empty, Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(1, 1, matches)
+    val json = result.formatReport("json")
+    // The class name contains a quote; must be escaped as \" in JSON string
+    assert(json.contains("\\\"inner\\\""))
+    assert(!json.contains("\"inner\""))  // raw unescaped quote would break JSON
+  }
+
+  test("formatReport txt empty result shows only summary line") {
+    val result = ScanResult(5, 0, Seq.empty)
+    val txt = result.formatReport("txt")
+    assert(!txt.contains("EXCLUDED"))
+    assert(!txt.contains("RESCUED"))
+    assert(txt.contains("Summary: 5 classes scanned, 0 methods excluded, 0 methods rescued"))
+  }
+
   // Helper to delete directory recursively
   private def deleteRecursively(path: Path): Unit = {
     if (Files.exists(path)) {

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
@@ -403,10 +403,14 @@ class VerifyScannerSpec extends AnyFunSuite {
     assert(json.contains("\"rescued\""))
     assert(json.contains("\"com.example.Foo\""))
     assert(json.contains("\"bar\""))
+    // Both excluded and rescued entries must use "exclusionRuleIds" (consistent schema)
+    assert(json.contains("\"exclusionRuleIds\""), "excluded entries must use exclusionRuleIds key")
+    assert(!json.contains("\"ruleIds\""), "legacy ruleIds key must not appear")
     assert(json.contains("\"rule1\""))
     assert(json.contains("\"com.example.Baz\""))
     assert(json.contains("\"excl-id\""))
     assert(json.contains("\"incl-id\""))
+    assert(json.contains("\"inclusionRuleIds\""), "rescued entries must use inclusionRuleIds key")
   }
 
   test("formatReport json handles empty excluded and rescued") {
@@ -440,11 +444,20 @@ class VerifyScannerSpec extends AnyFunSuite {
     assert(lines(0) == "outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds")
   }
 
-  test("formatReport defaults to txt for unknown format") {
+  test("formatReport throws IllegalArgumentException for unknown format") {
     val result = ScanResult(1, 0, Seq.empty)
-    val output = result.formatReport("unknown")
-    assert(output.contains("Summary:"))
-    assert(!output.contains("{"))
+    val ex = intercept[IllegalArgumentException] {
+      result.formatReport("unknown")
+    }
+    assert(ex.getMessage.contains("unknown"))
+    assert(ex.getMessage.contains("Supported"))
+  }
+
+  test("formatReport throws IllegalArgumentException for empty format string") {
+    val result = ScanResult(1, 0, Seq.empty)
+    intercept[IllegalArgumentException] {
+      result.formatReport("")
+    }
   }
 
   test("formatReport is case-insensitive for txt") {
@@ -503,6 +516,25 @@ class VerifyScannerSpec extends AnyFunSuite {
     // The class name contains a quote; must be escaped as \" in JSON string
     assert(json.contains("\\\"inner\\\""))
     assert(!json.contains("\"inner\""))  // raw unescaped quote would break JSON
+  }
+
+  test("formatReport json escapes backslash in field values") {
+    val matches = Seq(
+      MatchedMethod("com.example.Foo", "bar\\baz", "()V", Excluded, Seq("r1"), Seq.empty, Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(1, 1, matches)
+    val json = result.formatReport("json")
+    assert(json.contains("\"bar\\\\baz\""), "backslash must be escaped to \\\\ in JSON")
+  }
+
+  test("formatReport json escapes newline in field values") {
+    val matches = Seq(
+      MatchedMethod("com.example.Foo", "bar\nbaz", "()V", Excluded, Seq("r1"), Seq.empty, Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(1, 1, matches)
+    val json = result.formatReport("json")
+    assert(json.contains("\"bar\\nbaz\""), "newline must be escaped to \\n in JSON")
+    assert(!json.contains("\n  ]") || !json.contains("bar\nbaz"), "raw newline in string value would break JSON")
   }
 
   test("formatReport txt empty result shows only summary line") {

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
@@ -364,6 +364,89 @@ class VerifyScannerSpec extends AnyFunSuite {
     }
   }
 
+  // --- formatReport tests ---
+
+  test("formatReport txt produces human-readable output without [verify] prefix") {
+    val matches = Seq(
+      MatchedMethod("com.example.Foo", "bar", "()V", Excluded, Seq("rule1"), Seq.empty, Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(1, 1, matches)
+    val txt = result.formatReport("txt")
+    assert(txt.contains("EXCLUDED"))
+    assert(txt.contains("com.example.Foo"))
+    assert(txt.contains("#bar()V"))
+    assert(txt.contains("rule-id:rule1"))
+    assert(txt.contains("Summary:"))
+    assert(!txt.contains("[verify]"))
+  }
+
+  test("formatReport txt includes RESCUED section") {
+    val matches = Seq(
+      MatchedMethod("com.example.Bar", "apply", "()V", Rescued, Seq("excl"), Seq("incl"), Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(1, 1, matches)
+    val txt = result.formatReport("txt")
+    assert(txt.contains("RESCUED"))
+    assert(txt.contains("excl:excl"))
+    assert(txt.contains("incl:incl"))
+  }
+
+  test("formatReport json produces valid JSON structure") {
+    val matches = Seq(
+      MatchedMethod("com.example.Foo", "bar", "()V", Excluded, Seq("rule1"), Seq.empty, Opcodes.ACC_PUBLIC),
+      MatchedMethod("com.example.Baz", "run", "()V", Rescued, Seq("excl-id"), Seq("incl-id"), Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(2, 2, matches)
+    val json = result.formatReport("json")
+    assert(json.contains("\"classesScanned\": 2"))
+    assert(json.contains("\"excluded\""))
+    assert(json.contains("\"rescued\""))
+    assert(json.contains("\"com.example.Foo\""))
+    assert(json.contains("\"bar\""))
+    assert(json.contains("\"rule1\""))
+    assert(json.contains("\"com.example.Baz\""))
+    assert(json.contains("\"excl-id\""))
+    assert(json.contains("\"incl-id\""))
+  }
+
+  test("formatReport json handles empty excluded and rescued") {
+    val result = ScanResult(3, 0, Seq.empty)
+    val json = result.formatReport("json")
+    assert(json.contains("\"classesScanned\": 3"))
+    assert(json.contains("\"excluded\": []"))
+    assert(json.contains("\"rescued\": []"))
+  }
+
+  test("formatReport csv has correct header and rows") {
+    val matches = Seq(
+      MatchedMethod("com.example.Foo", "bar", "()V", Excluded, Seq("rule1"), Seq.empty, Opcodes.ACC_PUBLIC),
+      MatchedMethod("com.example.Baz", "run", "()V", Rescued, Seq("excl-id"), Seq("incl-id"), Opcodes.ACC_PUBLIC)
+    )
+    val result = ScanResult(2, 2, matches)
+    val csv = result.formatReport("csv")
+    val lines = csv.split("\n")
+    assert(lines(0) == "outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds")
+    assert(lines.exists(l => l.startsWith("EXCLUDED,com.example.Foo,bar")))
+    assert(lines.exists(l => l.startsWith("RESCUED,com.example.Baz,run")))
+    assert(lines.exists(l => l.contains("rule1")))
+    assert(lines.exists(l => l.contains("excl-id") && l.contains("incl-id")))
+  }
+
+  test("formatReport csv has only header when no matches") {
+    val result = ScanResult(1, 0, Seq.empty)
+    val csv = result.formatReport("csv")
+    val lines = csv.split("\n").filter(_.nonEmpty)
+    assert(lines.length == 1)
+    assert(lines(0) == "outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds")
+  }
+
+  test("formatReport defaults to txt for unknown format") {
+    val result = ScanResult(1, 0, Seq.empty)
+    val output = result.formatReport("unknown")
+    assert(output.contains("Summary:"))
+    assert(!output.contains("{"))
+  }
+
   // Helper to delete directory recursively
   private def deleteRecursively(path: Path): Unit = {
     if (Files.exists(path)) {

--- a/sbt-plugin/README.md
+++ b/sbt-plugin/README.md
@@ -141,11 +141,11 @@ EXCLUDED (10 methods):
     #productIterator()Lscala/collection/Iterator;  rule-id:scala-product-iterator
     #productPrefix()Ljava/lang/String;  rule-id:scala-product-prefix
 
-RESCUED by include rules (1 methods):
+RESCUED by include rules (1 method):
   example.Calculator
     #toString()Ljava/lang/String;  excl:scala-tostring → incl:rescue-calc-tostring
 
-Summary: 3 classes scanned, 10 methods excluded, 1 methods rescued
+Summary: 3 classes scanned, 10 methods excluded, 1 method rescued
 ```
 
 **json**:

--- a/sbt-plugin/README.md
+++ b/sbt-plugin/README.md
@@ -154,8 +154,8 @@ Summary: 3 classes scanned, 10 methods excluded, 1 method rescued
 {
   "classesScanned": 3,
   "excluded": [
-    {"class": "example.Calculator", "method": "add", "descriptor": "(DD)D", "ruleIds": ["local-calc-add"]},
-    {"class": "example.Calculator", "method": "copy", "descriptor": "(I)Lexample/Calculator;", "ruleIds": ["scala-copy"]}
+    {"class": "example.Calculator", "method": "add", "descriptor": "(DD)D", "exclusionRuleIds": ["local-calc-add"]},
+    {"class": "example.Calculator", "method": "copy", "descriptor": "(I)Lexample/Calculator;", "exclusionRuleIds": ["scala-copy"]}
   ],
   "rescued": [
     {"class": "example.Calculator", "method": "toString", "descriptor": "()Ljava/lang/String;", "exclusionRuleIds": ["scala-tostring"], "inclusionRuleIds": ["rescue-calc-tostring"]}

--- a/sbt-plugin/README.md
+++ b/sbt-plugin/README.md
@@ -121,7 +121,8 @@ Then run `sbt jmfVerify`; the report is written alongside the usual console outp
 }
 ```
 
-The CSV format uses `outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds` as its header row; multiple rule IDs within one cell are separated by `|`.
+The CSV format uses `outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds` as its header row; multiple
+ rule IDs within one cell are separated by `|`.
 
 ### `jacocoReport`
 

--- a/sbt-plugin/README.md
+++ b/sbt-plugin/README.md
@@ -113,7 +113,7 @@ Then run `sbt jmfVerify`; the report is written alongside the usual console outp
 
 The examples below use a rules file with all three rule kinds:
 
-```
+```text
 # Global rule (matches any class)
 *#copy(*)                               id:scala-copy
 *#toString(*)                           id:scala-tostring
@@ -128,7 +128,7 @@ example.Calculator#add(*)               id:local-calc-add
 
 **txt** (default):
 
-```
+```text
 EXCLUDED (10 methods):
   example.Calculator
     #add(DD)D  rule-id:local-calc-add
@@ -163,7 +163,8 @@ Summary: 3 classes scanned, 10 methods excluded, 1 methods rescued
 }
 ```
 
-**csv** — header row is `outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds`; multiple rule IDs within one cell are separated by `|`:
+**csv** — header row is `outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds`; multiple rule IDs within
+ one cell are separated by `|`:
 
 ```csv
 outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds

--- a/sbt-plugin/README.md
+++ b/sbt-plugin/README.md
@@ -101,6 +101,28 @@ Example output:
 - **Rescued** — matched by an exclusion rule *and* an include rule (`+…`). Because include rules always win, the
  method stays in coverage. The `excl:… → incl:…` trace shows which rules were involved.
 
+To export the results to a file for CI traceability or downstream tooling, set `jmfReportFile`:
+
+```scala
+// build.sbt
+jmfReportFile   := Some(target.value / "jmf-report.json")
+jmfReportFormat := "json"   // or "txt" (default) / "csv"
+```
+
+Then run `sbt jmfVerify`; the report is written alongside the usual console output. The JSON format:
+
+```json
+{
+  "classesScanned": 42,
+  "excluded": [
+    {"class": "com.example.User", "method": "copy", "descriptor": "(I)Lcom/example/User;", "ruleIds": ["case-copy"]}
+  ],
+  "rescued": []
+}
+```
+
+The CSV format uses `outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds` as its header row; multiple rule IDs within one cell are separated by `|`.
+
 ### `jacocoReport`
 
 Runs the full coverage pipeline for a single module:
@@ -160,6 +182,8 @@ Only configure the settings below when you want to:
 | `jmfLocalRulesFile` | `File` | `jmf-rules.txt` | Fallback local rules file used only when both `jmfGlobalRules` and `jmfLocalRules` are `None` |
 | `jmfDryRun` | `Boolean` | `false` | Dry run mode - logs matches without modifying classes |
 | `jmfOutDir` | `File` | `target` | Base output directory; filtered classes are written under `jmfOutDir / "classes-filtered"` |
+| `jmfReportFile` | `Option[File]` | `None` | Write a filtered-methods report to this file. Works with `jmfVerify` and when `jmfDryRun = true`. If not set, output goes to console only. |
+| `jmfReportFormat` | `String` | `"txt"` | Report format: `txt` (plain text), `json`, or `csv`. Only used when `jmfReportFile` is set. |
 
 ### Examples
 

--- a/sbt-plugin/README.md
+++ b/sbt-plugin/README.md
@@ -232,7 +232,7 @@ Only configure the settings below when you want to:
 | `jmfLocalRulesFile` | `File` | `jmf-rules.txt` | Fallback local rules file used only when both `jmfGlobalRules` and `jmfLocalRules` are `None` |
 | `jmfDryRun` | `Boolean` | `false` | Dry run mode - logs matches without modifying classes |
 | `jmfOutDir` | `File` | `target` | Base output directory; filtered classes are written under `jmfOutDir / "classes-filtered"` |
-| `jmfReportFile` | `Option[File]` | `None` | Write a filtered-methods report to this file. Works with `jmfVerify` and when `jmfDryRun = true`. If not set, output goes to console only. |
+| `jmfReportFile` | `Option[File]` | `None` | Write a filtered-methods report to this file. Works with `jmfVerify` and `jmfRewrite` (including `jmfDryRun = true`). If not set, output goes to console only. |
 | `jmfReportFormat` | `String` | `"txt"` | Report format: `txt` (plain text), `json`, or `csv`. Only used when `jmfReportFile` is set. |
 
 ### Examples

--- a/sbt-plugin/README.md
+++ b/sbt-plugin/README.md
@@ -109,20 +109,68 @@ jmfReportFile   := Some(target.value / "jmf-report.json")
 jmfReportFormat := "json"   // or "txt" (default) / "csv"
 ```
 
-Then run `sbt jmfVerify`; the report is written alongside the usual console output. The JSON format:
+Then run `sbt jmfVerify`; the report is written alongside the usual console output.
+
+The examples below use a rules file with all three rule kinds:
+
+```
+# Global rule (matches any class)
+*#copy(*)                               id:scala-copy
+*#toString(*)                           id:scala-tostring
+# ... other global rules ...
+
+# Local rule (class-specific)
+example.Calculator#add(*)               id:local-calc-add
+
+# Include rule (rescues toString from the global exclusion above)
++example.Calculator#toString(*)         id:rescue-calc-tostring
+```
+
+**txt** (default):
+
+```
+EXCLUDED (10 methods):
+  example.Calculator
+    #add(DD)D  rule-id:local-calc-add
+    #canEqual(Ljava/lang/Object;)Z  rule-id:scala-canequal
+    #copy(I)Lexample/Calculator;  rule-id:scala-copy
+    #equals(Ljava/lang/Object;)Z  rule-id:scala-equals
+    #hashCode()I  rule-id:scala-hashcode
+    #productArity()I  rule-id:scala-product-arity
+    #productElement(I)Ljava/lang/Object;  rule-id:scala-product-element
+    #productIterator()Lscala/collection/Iterator;  rule-id:scala-product-iterator
+    #productPrefix()Ljava/lang/String;  rule-id:scala-product-prefix
+
+RESCUED by include rules (1 methods):
+  example.Calculator
+    #toString()Ljava/lang/String;  excl:scala-tostring → incl:rescue-calc-tostring
+
+Summary: 3 classes scanned, 10 methods excluded, 1 methods rescued
+```
+
+**json**:
 
 ```json
 {
-  "classesScanned": 42,
+  "classesScanned": 3,
   "excluded": [
-    {"class": "com.example.User", "method": "copy", "descriptor": "(I)Lcom/example/User;", "ruleIds": ["case-copy"]}
+    {"class": "example.Calculator", "method": "add", "descriptor": "(DD)D", "ruleIds": ["local-calc-add"]},
+    {"class": "example.Calculator", "method": "copy", "descriptor": "(I)Lexample/Calculator;", "ruleIds": ["scala-copy"]}
   ],
-  "rescued": []
+  "rescued": [
+    {"class": "example.Calculator", "method": "toString", "descriptor": "()Ljava/lang/String;", "exclusionRuleIds": ["scala-tostring"], "inclusionRuleIds": ["rescue-calc-tostring"]}
+  ]
 }
 ```
 
-The CSV format uses `outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds` as its header row; multiple
- rule IDs within one cell are separated by `|`.
+**csv** — header row is `outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds`; multiple rule IDs within one cell are separated by `|`:
+
+```csv
+outcome,class,method,descriptor,exclusionRuleIds,inclusionRuleIds
+EXCLUDED,example.Calculator,add,(DD)D,local-calc-add,
+EXCLUDED,example.Calculator,copy,(I)Lexample/Calculator;,scala-copy,
+RESCUED,example.Calculator,toString,()Ljava/lang/String;,scala-tostring,rescue-calc-tostring
+```
 
 ### `jacocoReport`
 

--- a/sbt-plugin/src/main/scala/morana/coverage/JacocoFilterPlugin.scala
+++ b/sbt-plugin/src/main/scala/morana/coverage/JacocoFilterPlugin.scala
@@ -140,6 +140,8 @@ object JacocoFilterPlugin extends AutoPlugin {
     jmfDryRun := false,
     jmfEnabled := true,
     jmfInitRulesForce := false,
+    jmfReportFile := None,
+    jmfReportFormat := "txt",
 
     jmfInitRules := {
       val log = streams.value.log
@@ -166,12 +168,14 @@ object JacocoFilterPlugin extends AutoPlugin {
     jmfVerify := {
       val _ = (Compile / compile).value
 
-      val rulesFile   = jmfLocalRulesFile.value
-      val globalRules = jmfGlobalRules.value
-      val localRules  = jmfLocalRules.value
-      val log         = streams.value.log
-      val workDir     = baseDirectory.value
-      val classesIn   = (Compile / classDirectory).value
+      val rulesFile    = jmfLocalRulesFile.value
+      val globalRules  = jmfGlobalRules.value
+      val localRules   = jmfLocalRules.value
+      val log          = streams.value.log
+      val workDir      = baseDirectory.value
+      val classesIn    = (Compile / classDirectory).value
+      val reportFile   = jmfReportFile.value
+      val reportFormat = jmfReportFormat.value
 
       val jmfJars: Seq[File] = (Jmf / update).value.matching(artifactFilter(`type` = "jar")).distinct
       val cpStr = jmfJars.map(_.getAbsolutePath).mkString(java.io.File.pathSeparator)
@@ -210,7 +214,11 @@ object JacocoFilterPlugin extends AutoPlugin {
               Seq("--local-rules", rulesFile.getAbsolutePath)
             }
 
-            val args = baseArgs ++ rulesArgs
+            val reportArgs = reportFile.toSeq.flatMap(f =>
+              Seq("--report-file", f.getAbsolutePath, "--report-format", reportFormat)
+            )
+
+            val args = baseArgs ++ rulesArgs ++ reportArgs
 
             log.info(s"[jmf] verify: ${args.mkString(" ")}")
             val code = scala.sys.process.Process(args, workDir).!
@@ -223,13 +231,15 @@ object JacocoFilterPlugin extends AutoPlugin {
     jmfRewrite := {
       val _ = (Compile / compile).value
 
-      val rulesFile   = jmfLocalRulesFile.value
-      val globalRules = jmfGlobalRules.value
-      val localRules  = jmfLocalRules.value
-      val log         = streams.value.log
-      val workDir     = baseDirectory.value
-      val classesIn   = (Compile / classDirectory).value
-      val enabled     = jacocoPluginEnabled.value
+      val rulesFile    = jmfLocalRulesFile.value
+      val globalRules  = jmfGlobalRules.value
+      val localRules   = jmfLocalRules.value
+      val log          = streams.value.log
+      val workDir      = baseDirectory.value
+      val classesIn    = (Compile / classDirectory).value
+      val enabled      = jacocoPluginEnabled.value
+      val reportFile   = jmfReportFile.value
+      val reportFormat = jmfReportFormat.value
 
       val jmfJars: Seq[File] = (Jmf / update).value.matching(artifactFilter(`type` = "jar")).distinct
       val cpStr = jmfJars.map(_.getAbsolutePath).mkString(java.io.File.pathSeparator)
@@ -277,7 +287,10 @@ object JacocoFilterPlugin extends AutoPlugin {
             }
             
             val dryRunArgs = if (jmfDryRun.value) Seq("--dry-run") else Seq.empty
-            val args = baseArgs ++ rulesArgs ++ dryRunArgs
+            val reportArgs = reportFile.toSeq.flatMap(f =>
+              Seq("--report-file", f.getAbsolutePath, "--report-format", reportFormat)
+            )
+            val args = baseArgs ++ rulesArgs ++ dryRunArgs ++ reportArgs
 
             log.info(s"[jmf] rewrite: ${args.mkString(" ")}")
             val code = scala.sys.process.Process(args, workDir).!

--- a/sbt-plugin/src/main/scala/morana/coverage/Keys.scala
+++ b/sbt-plugin/src/main/scala/morana/coverage/Keys.scala
@@ -46,7 +46,7 @@ object Keys {
     val jmfInitRules       = taskKey[File]("Create default jmf-rules.txt if it does not exist")
     val jmfInitRulesForce  = settingKey[Boolean]("Force overwrite existing jmf-rules.txt (default: false)")
     val jmfVerify          = taskKey[Unit]("On-demand scan: show which methods would be excluded from coverage by current rules")
-    val jmfReportFile      = settingKey[Option[File]]("Write filtered-methods report to this file (used with jmfVerify or jmfDryRun=true)")
+    val jmfReportFile      = settingKey[Option[File]]("Write filtered-methods report to this file (used with jmfVerify or jmfRewrite, including dry-run mode)")
     val jmfReportFormat    = settingKey[String]("Report format for jmfReportFile: txt (default), json, or csv")
   }
 }

--- a/sbt-plugin/src/main/scala/morana/coverage/Keys.scala
+++ b/sbt-plugin/src/main/scala/morana/coverage/Keys.scala
@@ -46,5 +46,7 @@ object Keys {
     val jmfInitRules       = taskKey[File]("Create default jmf-rules.txt if it does not exist")
     val jmfInitRulesForce  = settingKey[Boolean]("Force overwrite existing jmf-rules.txt (default: false)")
     val jmfVerify          = taskKey[Unit]("On-demand scan: show which methods would be excluded from coverage by current rules")
+    val jmfReportFile      = settingKey[Option[File]]("Write filtered-methods report to this file (used with jmfVerify or jmfDryRun=true)")
+    val jmfReportFormat    = settingKey[String]("Report format for jmfReportFile: txt (default), json, or csv")
   }
 }


### PR DESCRIPTION
### New features

- **Report file export** — filtered-methods report can now be written to a file after rewrite or verify.
  Configure via `--report-file <path>` and `--report-format txt|json|csv` (CLI),
  `jmfReportFile` / `jmfReportFormat` (sbt), or `jmf.reportFile` / `jmf.reportFormat` (Maven).
  Default format is `txt`; `json` and `csv` are also supported.
  Parent directories are created automatically if they do not exist.

Release Notes:
- Added `--report-file <path>` and `--report-format txt|json|csv` CLI flags to export the filtered-methods report to a file after rewrite or verify
- Added `jmfReportFile` and `jmfReportFormat` sbt settings (wired into `jmfVerify` and rewrite tasks)
- Added `jmf.reportFile` and `jmf.reportFormat` Maven parameters on both `rewrite` and `verify` mojos
- Default format is `txt`; `json` and `csv` are also supported; unknown format values are rejected with a validation error

Closes #59 
