### PR TITLE
feat: add support for unmatched rules reporting in CLI verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Unmatched rules report** in `--verify` mode — after scanning, prints an `UNMATCHED RULES`
+  section listing every rule that matched zero methods in the scanned class directory.
+  Covers both exclusion and include rules.
+- **`--error-on-unmatched` CLI flag** — when combined with `--verify`, exits with code `1` if
+  any rules are unmatched. Enables CI enforcement of rule hygiene.
+- **`forward-compat` rule marker** — annotate a rule with `forward-compat` to exempt it from
+  the unmatched-rule warning. Use for rules targeting classes present in production builds
+  but absent from the current module's test classpath. Forward-compat rules are labelled
+  `(forward-compat)` in the `--verify` active-rules listing for easy identification.
+- Report formats (txt, json, csv) include unmatched rule information: txt/printReport add an
+  `UNMATCHED RULES` block, JSON adds an `unmatchedRules` array, CSV adds `UNMATCHED_RULE` rows.
+
 ## [2.0.1] — 2026-02-14
 
 ### Fixed

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -69,6 +69,7 @@ RIGHT: *#*(*) synthetic    (space separates flag from descriptor)
 - `name-contains:<s>` — Method name must contain `<s>`
 - `name-starts:<s>` — Method name must start with `<s>`
 - `name-ends:<s>` — Method name must end with `<s>`
+- `forward-compat` — Exempt from the *unmatched rules* warning (see [Verify: Unmatched Rules](#unmatched-rules))
 
 IMPORTANT: predicates must be space-separated from the descriptor.
 
@@ -177,6 +178,14 @@ grep -n '[a-z]\.[A-Z]' jmf-rules.txt | grep -v '^#'
 ```
 
 Any matches likely contain human-readable class names in descriptors.
+
+**8.** Use `--verify --error-on-unmatched` in CI to catch rules that silently stopped matching
+(e.g. after a rename or refactor). Rules that intentionally target classes absent from the current
+build should be marked `forward-compat` to suppress the warning:
+
+```text
+*com.example.ProdOnlyService#copy(*) forward-compat id:prod-only-copy
+```
 
 ---
 
@@ -500,6 +509,60 @@ java -cp ... io.moranaapps.jacocomethodfilter.CoverageRewriter \
 - **Rescued** — matched by an exclusion rule *and* an include rule (`+…`). Include always wins.
   The `excl:… → incl:…` trace shows which rules were involved.
 
+### Unmatched Rules
+
+After the EXCLUDED / RESCUED sections, `--verify` prints an **UNMATCHED RULES** section listing
+every rule that matched zero methods in the scanned class directory:
+
+```text
+[verify] UNMATCHED RULES (2 rules matched zero methods):
+[verify]   *com.example.DoesNotExist#copy(*)  id:ghost-copy  [local: jmf-rules.txt]
+[verify]   *QueryResult#noMore()  (no id)  [local: jmf-rules.txt]
+```
+
+An unmatched rule almost always indicates a misconfiguration:
+
+- Wrong FQCN prefix (missing `*`, wrong package, stale class name).
+- Human-readable descriptor instead of JVM format (`int` → should be `I`).
+- Method was removed but the rule was never cleaned up.
+
+To treat unmatched rules as a hard CI failure, add `--error-on-unmatched`:
+
+```bash
+java -cp ... io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --verify \
+  --in target/classes \
+  --local-rules jmf-rules.txt \
+  --error-on-unmatched
+```
+
+Exit code is `1` when any unmatched rules exist; `0` when all rules matched.
+
+### Forward-Compatible Rules
+
+Some rules are intentionally written to target classes present in a *production* build but absent
+from a given module's test classpath. These rules would always appear in UNMATCHED RULES without
+any real misconfiguration.
+
+Mark such rules with the `forward-compat` token to exempt them from the unmatched check:
+
+```text
+# This service exists in production but is not compiled in the payment module.
+*com.example.OrderService#copy(*) forward-compat id:order-copy
+```
+
+Forward-compat rules are still active — if the class later appears in the build, they filter
+normally. They are only excluded from the "zero-match" warning.
+
+In the `--verify` active-rules listing, forward-compat rules are labelled `(forward-compat)`
+so you can identify them at a glance:
+
+```text
+[verify] Active rules from local: jmf-rules.txt:
+[verify]   1. [-] id:order-copy (forward-compat)  [local: jmf-rules.txt]
+[verify]   2. [-] id:prod-copy  [local: jmf-rules.txt]
+```
+
 ---
 
 ## Diagnostic Workflow
@@ -608,6 +671,9 @@ globally and rescue lazy vals with real logic:
 | `--local-rules <path>` | At least one of the two | Local rules file path |
 | `--dry-run` | No | Only print matches; do not modify classes |
 | `--verify` | No | Read-only scan: list all methods that would be excluded by rules |
+| `--error-on-unmatched` | No | Exit non-zero if any rules matched zero methods (requires `--verify`) |
+| `--report-file <path>` | No | Write the filtered-methods report to this file |
+| `--report-format <fmt>` | No | Report format: `txt` (default), `json`, or `csv` (requires `--report-file`) |
 
 In rewrite mode, `--out` is required (omit only when using `--verify`).
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -38,6 +38,7 @@ bash integration-tests/test-sbt-init-rules.sh
 | `test-sbt-verify.sh` | `sbt jmfVerify` shows methods that would be filtered (read-only scan) |
 | `test-mvn-verify.sh` | `mvn jacoco-method-filter:verify` shows methods that would be filtered |
 | `test-cli-verify.sh` | CLI `--verify` mode shows methods that would be filtered |
+| `test-cli-verify-unmatched.sh` | CLI `--verify` UNMATCHED RULES report and `--error-on-unmatched` flag |
 | `test-sbt-basic.sh` | `examples/sbt-basic` passes tests without filtering, then with filtering + report generation |
 | `test-sbt-report-custom.sh` | sbt plugin with custom report settings (formats, title, encoding) verifies only specified formats are generated |
 | `test-maven-basic.sh` | `examples/maven-basic` (Java) passes tests without and with `-Pcode-coverage` |

--- a/integration-tests/test-cli-verify-unmatched.sh
+++ b/integration-tests/test-cli-verify-unmatched.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Test: CLI --verify UNMATCHED RULES report and --error-on-unmatched flag.
+#
+# Covers:
+#   1. Rules that match zero methods appear in "UNMATCHED RULES" section.
+#   2. Rules that do match are NOT listed as unmatched.
+#   3. forward-compat rules are excluded from the unmatched list.
+#   4. --error-on-unmatched exits non-zero when unmatched rules exist.
+#   5. --error-on-unmatched exits zero when all rules matched.
+#
+# Prerequisite: rewriter-core published locally (run 'sbt publishLocal' first).
+# ---------------------------------------------------------------------------
+source "$(dirname "$0")/helpers.sh"
+
+TEST_NAME="cli-verify-unmatched"
+info "Running: $TEST_NAME"
+
+# ── Set up project ─────────────────────────────────────────────────────────
+cp -R "$REPO_ROOT/integration-tests/fixtures/sbt-basic" "$WORK_DIR/project"
+cp -R "$REPO_ROOT/examples/sbt-basic/src"               "$WORK_DIR/project/src"
+cd "$WORK_DIR/project"
+
+# Compile to produce .class files and warm up the Coursier cache.
+run_cmd "$TEST_NAME — compiling project" sbt compile
+run_cmd "$TEST_NAME — exporting classpath" sbt "export runtime:dependencyClasspath"
+
+assert_dir_not_empty "target/scala-2.12/classes" \
+  "$TEST_NAME — compiled classes exist"
+
+# ── Locate JARs ────────────────────────────────────────────────────────────
+CORE_JAR=$(
+  find ~/.ivy2/local/io.github.moranaapps/jacoco-method-filter-core_2.12 \
+    -name "jacoco-method-filter-core_2.12.jar" 2>/dev/null | \
+  while IFS= read -r f; do
+    timestamp=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null)
+    printf '%s\t%s\n' "$timestamp" "$f"
+  done | sort -rn | head -1 | cut -f2- || true
+)
+
+SCALA_LIB=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "scala-library-2.12*.jar" 2>/dev/null | head -1 || true)
+SCOPT_JAR=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "scopt_2.12-*.jar"        2>/dev/null | head -1 || true)
+
+if [[ -z "$CORE_JAR" || ! -f "$CORE_JAR" ]]; then
+  fail "$TEST_NAME — core JAR not found in ~/.ivy2/local (run 'sbt publishLocal' first)"
+fi
+if [[ -z "$SCALA_LIB" || ! -f "$SCALA_LIB" ]]; then
+  fail "$TEST_NAME — Scala library not found in Coursier cache"
+fi
+if [[ -z "$SCOPT_JAR" || ! -f "$SCOPT_JAR" ]]; then
+  fail "$TEST_NAME — scopt JAR not found in Coursier cache"
+fi
+
+CP="$CORE_JAR:$SCALA_LIB:$SCOPT_JAR"
+
+# ── Helper: run CLI verify with a given rules file ─────────────────────────
+run_verify() {
+  local rules_file="$1"; shift
+  java -cp "$CP" io.moranaapps.jacocomethodfilter.CoverageRewriter \
+    --verify \
+    --in target/scala-2.12/classes \
+    --local-rules "$rules_file" "$@" 2>&1 || true
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 1 — Rule with no matching class appears in UNMATCHED RULES section
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 1: unmatched rule appears in UNMATCHED RULES section"
+
+cat > rules-unmatched.txt <<'EOF'
+# A rule that will never match (class does not exist in the build)
+*com.example.DoesNotExist#copy(*) id:ghost-copy
+# A rule that DOES match (Calculator is a case class with boilerplate)
+*Calculator#copy(*) id:calc-copy
+EOF
+
+OUTPUT=$(run_verify rules-unmatched.txt)
+echo "─── output ───"
+echo "$OUTPUT"
+echo "─── end output ───"
+
+echo "$OUTPUT" | grep -q "UNMATCHED RULES" || \
+  fail "$TEST_NAME — test 1: output missing 'UNMATCHED RULES' section"
+
+echo "$OUTPUT" | grep -q "ghost-copy" || \
+  fail "$TEST_NAME — test 1: unmatched rule id 'ghost-copy' not listed"
+
+# The matched rule must NOT appear in UNMATCHED RULES
+# (it appears in the EXCLUDED section instead)
+UNMATCHED_SECTION=$(echo "$OUTPUT" | awk '/UNMATCHED RULES/,/Summary:/' | head -20)
+if echo "$UNMATCHED_SECTION" | grep -q "calc-copy"; then
+  fail "$TEST_NAME — test 1: matched rule 'calc-copy' must not be in UNMATCHED RULES"
+fi
+
+pass "$TEST_NAME — test 1: unmatched rule correctly reported"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 2 — All rules matched → no UNMATCHED RULES section
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 2: all rules matched → no UNMATCHED RULES section"
+
+cat > rules-all-matched.txt <<'EOF'
+*Calculator#copy(*) id:calc-copy
+*Calculator#equals(*) id:calc-equals
+EOF
+
+OUTPUT2=$(run_verify rules-all-matched.txt)
+echo "─── output ───"
+echo "$OUTPUT2"
+echo "─── end output ───"
+
+if echo "$OUTPUT2" | grep -q "UNMATCHED RULES"; then
+  fail "$TEST_NAME — test 2: UNMATCHED RULES section should not appear when all rules matched"
+fi
+
+pass "$TEST_NAME — test 2: no UNMATCHED RULES when all rules matched"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 3 — forward-compat rules are excluded from UNMATCHED report
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 3: forward-compat rules excluded from UNMATCHED report"
+
+cat > rules-fwd-compat.txt <<'EOF'
+# forward-compat: targets a class present in production but not this test build
+*com.example.FutureService#copy(*) forward-compat id:future-copy
+# Plain unmatched: should be reported
+*com.example.AlsoMissing#process(*) id:plain-missing
+EOF
+
+OUTPUT3=$(run_verify rules-fwd-compat.txt)
+echo "─── output ───"
+echo "$OUTPUT3"
+echo "─── end output ───"
+
+echo "$OUTPUT3" | grep -q "UNMATCHED RULES" || \
+  fail "$TEST_NAME — test 3: UNMATCHED RULES section must appear (plain-missing rule)"
+
+echo "$OUTPUT3" | grep -q "plain-missing" || \
+  fail "$TEST_NAME — test 3: 'plain-missing' rule must appear in UNMATCHED RULES"
+
+# forward-compat rules must show "(forward-compat)" in the active rules listing
+echo "$OUTPUT3" | grep -q "(forward-compat)" || \
+  fail "$TEST_NAME — test 3: active rules listing must indicate (forward-compat) for future-copy rule"
+
+# forward-compat rule must NOT appear in the UNMATCHED RULES section.
+# NOTE: its id DOES appear in the "Active rules" listing above — scope the check
+# to only the UNMATCHED RULES section to avoid a false positive.
+UNMATCHED_SECTION3=$(echo "$OUTPUT3" | awk '/UNMATCHED RULES/,0')
+if echo "$UNMATCHED_SECTION3" | grep -q "future-copy"; then
+  fail "$TEST_NAME — test 3: forward-compat rule 'future-copy' must NOT appear in UNMATCHED RULES"
+fi
+
+pass "$TEST_NAME — test 3: forward-compat rule correctly exempted"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 4 — --error-on-unmatched exits non-zero when unmatched rules exist
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 4: --error-on-unmatched exits non-zero on unmatched rules"
+
+EXIT_CODE4=0
+OUTPUT4=$(java -cp "$CP" io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --verify \
+  --in target/scala-2.12/classes \
+  --local-rules rules-unmatched.txt \
+  --error-on-unmatched 2>&1) || EXIT_CODE4=$?
+
+echo "─── output ───"
+echo "$OUTPUT4"
+echo "─── end output ───"
+
+if [[ $EXIT_CODE4 -eq 0 ]]; then
+  fail "$TEST_NAME — test 4: --error-on-unmatched must exit non-zero when unmatched rules exist (got 0)"
+fi
+
+pass "$TEST_NAME — test 4: --error-on-unmatched exits non-zero ($EXIT_CODE4)"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 5 — --error-on-unmatched exits zero when all rules matched
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 5: --error-on-unmatched exits zero when all rules matched"
+
+OUTPUT5=$(java -cp "$CP" io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --verify \
+  --in target/scala-2.12/classes \
+  --local-rules rules-all-matched.txt \
+  --error-on-unmatched 2>&1)
+EXIT_CODE5=$?
+echo "─── output ───"
+echo "$OUTPUT5"
+echo "─── end output ───"
+
+if [[ $EXIT_CODE5 -ne 0 ]]; then
+  fail "$TEST_NAME — test 5: --error-on-unmatched must exit zero when all rules matched (got $EXIT_CODE5)"
+fi
+
+pass "$TEST_NAME — test 5: --error-on-unmatched exits zero when all rules matched"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 6 — --error-on-unmatched rejected without --verify (CLI validation)
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 6: --error-on-unmatched without --verify is rejected"
+
+EXIT_CODE6=0
+OUTPUT6=$(java -cp "$CP" io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --in target/scala-2.12/classes \
+  --out /tmp/jmf-out-$$ \
+  --local-rules rules-all-matched.txt \
+  --error-on-unmatched 2>&1) || EXIT_CODE6=$?
+
+echo "─── output ───"
+echo "$OUTPUT6"
+echo "─── end output ───"
+
+if [[ $EXIT_CODE6 -eq 0 ]]; then
+  fail "$TEST_NAME — test 6: CLI must reject --error-on-unmatched without --verify"
+fi
+
+pass "$TEST_NAME — test 6: --error-on-unmatched correctly rejected without --verify"
+
+pass "$TEST_NAME"

--- a/integration-tests/test-cli-verify-unmatched.sh
+++ b/integration-tests/test-cli-verify-unmatched.sh
@@ -39,6 +39,8 @@ CORE_JAR=$(
 )
 
 SCALA_LIB=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "scala-library-2.12*.jar" 2>/dev/null | head -1 || true)
+ASM_JAR=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "asm-9.*.jar" 2>/dev/null | sort -V | tail -1 || true)
+ASM_COMMONS_JAR=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "asm-commons-9.*.jar" 2>/dev/null | sort -V | tail -1 || true)
 SCOPT_JAR=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "scopt_2.12-*.jar"        2>/dev/null | head -1 || true)
 
 if [[ -z "$CORE_JAR" || ! -f "$CORE_JAR" ]]; then
@@ -47,11 +49,17 @@ fi
 if [[ -z "$SCALA_LIB" || ! -f "$SCALA_LIB" ]]; then
   fail "$TEST_NAME — Scala library not found in Coursier cache"
 fi
+if [[ -z "$ASM_JAR" || ! -f "$ASM_JAR" ]]; then
+  fail "$TEST_NAME — ASM JAR not found in Coursier cache"
+fi
 if [[ -z "$SCOPT_JAR" || ! -f "$SCOPT_JAR" ]]; then
   fail "$TEST_NAME — scopt JAR not found in Coursier cache"
 fi
 
-CP="$CORE_JAR:$SCALA_LIB:$SCOPT_JAR"
+CP="$CORE_JAR:$SCALA_LIB:$ASM_JAR:$SCOPT_JAR"
+if [[ -n "$ASM_COMMONS_JAR" && -f "$ASM_COMMONS_JAR" ]]; then
+  CP="$CP:$ASM_COMMONS_JAR"
+fi
 
 # ── Helper: run CLI verify with a given rules file ─────────────────────────
 run_verify() {

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriter.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriter.scala
@@ -15,6 +15,7 @@ import java.nio.file.{Files, Path, Paths}
   * @param verify If true, run read-only scan mode
   * @param reportFile Optional path to write the filtered-methods report (txt/json/csv)
   * @param reportFormat Report format: txt (default), json, or csv
+  * @param errorOnUnmatched If true, exit non-zero when any rules matched zero methods (requires verify mode)
   */
 private[jacocomethodfilter] final case class CliConfig(
   in: Path = Paths.get("."),
@@ -24,7 +25,8 @@ private[jacocomethodfilter] final case class CliConfig(
   dryRun: Boolean = false,
   verify: Boolean = false,
   reportFile: Option[Path] = None,
-  reportFormat: String = "txt"
+  reportFormat: String = "txt",
+  errorOnUnmatched: Boolean = false
 )
 
 object CoverageRewriter {
@@ -81,8 +83,17 @@ object CoverageRewriter {
 
     println(s"[info] Verification complete: scanned ${result.classesScanned} class file(s), found ${result.totalMatched} method(s) matched by rules.")
 
+    if (result.unmatchedRules.nonEmpty && !cfg.errorOnUnmatched) {
+      println(s"[warn] ${result.unmatchedRules.size} rule(s) matched zero methods. Use --error-on-unmatched to enforce this as a build error.")
+    }
+
     cfg.reportFile.foreach { path =>
       writeReportFile(path, result.formatReport(cfg.reportFormat))
+    }
+
+    if (cfg.errorOnUnmatched && result.unmatchedRules.nonEmpty) {
+      println(s"[error] Aborting: ${result.unmatchedRules.size} unmatched rule(s) found (--error-on-unmatched is set).")
+      sys.exit(1)
     }
   }
 
@@ -174,11 +185,12 @@ object CoverageRewriter {
       }
       val idStr = rule.id.map(id => s"id:$id").getOrElse("(no id)")
       val flagsStr = if (rule.flags.nonEmpty) s" [${rule.flags.mkString(",")}]" else ""
+      val fwdCompatStr = if (rule.forwardCompat) " (forward-compat)" else ""
       val sourceStr = rule.source match {
         case GlobalSource(origin) => s" [global: $origin]"
         case LocalSource(path)    => s" [local: $path]"
         case _                    => ""
       }
-      println(s"[verify]   ${idx + 1}. [$modeStr] $idStr$flagsStr$sourceStr")
+      println(s"[verify]   ${idx + 1}. [$modeStr] $idStr$flagsStr$fwdCompatStr$sourceStr")
     }
 }

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
@@ -45,6 +45,10 @@ private[jacocomethodfilter] object CoverageRewriterCli {
         .action((_, c) => c.copy(verify = true))
         .text("Read-only scan: list all methods that would be excluded by rules")
 
+      opt[Unit]("error-on-unmatched")
+        .action((_, c) => c.copy(errorOnUnmatched = true))
+        .text("Exit non-zero if any rules matched zero methods (requires --verify)")
+
       opt[String]("report-file")
         .optional()
         .action((v, c) => c.copy(reportFile = Some(Paths.get(v))))
@@ -70,6 +74,8 @@ private[jacocomethodfilter] object CoverageRewriterCli {
           failure("--report-file must be a file path, not an existing directory")
         } else if (cfg.reportFile.isEmpty && cfg.reportFormat != "txt") {
           failure("--report-format requires --report-file to be set")
+        } else if (cfg.errorOnUnmatched && !cfg.verify) {
+          failure("--error-on-unmatched requires --verify")
         } else {
           success
         }

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/Rules.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/Rules.scala
@@ -42,7 +42,8 @@ final case class MethodRule(
                              mode: RuleMode = Exclude,     // exclude or include
                              source: RuleSource = LocalSource(""), // where this rule came from
                              forwardCompat: Boolean = false, // exempt from unmatched-rule warnings
-                             rawText: String = ""          // original rule line (for display in reports)
+                             rawText: String = "",          // original rule line (for debugging/logging)
+                             patternText: String = ""       // selector-only (cls#method(desc), no tokens) for display
                            )
 
 object Rules {
@@ -89,6 +90,9 @@ object Rules {
     val (main, restTokens) =
       if (firstWs < 0) (lineWithoutPrefix, "")
       else (lineWithoutPrefix.substring(0, firstWs), lineWithoutPrefix.substring(firstWs).trim)
+
+    // patternText = selector-only, no tokens (used for display in UNMATCHED RULES reports)
+    val patternText = if (mode == Include) s"+$main" else main
 
     val parts = main.split("#", 2)
     require(parts.length == 2, s"Missing '#' separator in rule: $raw")
@@ -155,7 +159,8 @@ object Rules {
       mode          = mode,
       source        = source,
       forwardCompat = forwardCompat,
-      rawText       = line
+      rawText       = line,
+      patternText   = patternText
     ))
   }
 

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/Rules.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/Rules.scala
@@ -40,7 +40,9 @@ final case class MethodRule(
                              nameStarts: Option[String],   // name-starts:<s>
                              nameEnds: Option[String],     // name-ends:<s>
                              mode: RuleMode = Exclude,     // exclude or include
-                             source: RuleSource = LocalSource("") // where this rule came from
+                             source: RuleSource = LocalSource(""), // where this rule came from
+                             forwardCompat: Boolean = false, // exempt from unmatched-rule warnings
+                             rawText: String = ""          // original rule line (for display in reports)
                            )
 
 object Rules {
@@ -114,6 +116,7 @@ object Rules {
     var nameContains = Option.empty[String]
     var nameStarts   = Option.empty[String]
     var nameEnds     = Option.empty[String]
+    var forwardCompat = false
 
     restTokens.replace(",", " ").split("\\s+").filter(_.nonEmpty).foreach {
       case t @ ("public" | "protected" | "private" | "synthetic" | "bridge" | "static" | "abstract") =>
@@ -123,6 +126,7 @@ object Rules {
       case kv if kv.startsWith("name-contains:")  => nameContains = Some(kv.stripPrefix("name-contains:"))
       case kv if kv.startsWith("name-starts:")    => nameStarts   = Some(kv.stripPrefix("name-starts:"))
       case kv if kv.startsWith("name-ends:")      => nameEnds     = Some(kv.stripPrefix("name-ends:"))
+      case "forward-compat"                        => forwardCompat = true
       case _ => () // ignore unknown tokens for forward-compat
     }
 
@@ -139,17 +143,19 @@ object Rules {
     ensureNoRegex(descSel,   "descriptor")
 
     Some(MethodRule(
-      cls          = Selectors.globToRegex(clsSel),
-      method       = Selectors.globToRegex(methodSel),
-      desc         = Selectors.globToRegex(descSel),
-      flags        = flags,
-      retGlob      = retGlob,     // note: still a glob
-      id           = id,
-      nameContains = nameContains,
-      nameStarts   = nameStarts,
-      nameEnds     = nameEnds,
-      mode         = mode,
-      source       = source
+      cls           = Selectors.globToRegex(clsSel),
+      method        = Selectors.globToRegex(methodSel),
+      desc          = Selectors.globToRegex(descSel),
+      flags         = flags,
+      retGlob       = retGlob,     // note: still a glob
+      id            = id,
+      nameContains  = nameContains,
+      nameStarts    = nameStarts,
+      nameEnds      = nameEnds,
+      mode          = mode,
+      source        = source,
+      forwardCompat = forwardCompat,
+      rawText       = line
     ))
   }
 

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
@@ -23,7 +23,8 @@ final case class MatchedMethod(
 final case class ScanResult(
                               classesScanned: Int,
                               totalMatched: Int,
-                              matches: Seq[MatchedMethod]
+                              matches: Seq[MatchedMethod],
+                              unmatchedRules: Seq[MethodRule] = Seq.empty
                             ) {
   def excludedMethods: Seq[MatchedMethod] = matches.filter(_.outcome == Excluded)
   def rescuedMethods: Seq[MatchedMethod] = matches.filter(_.outcome == Rescued)
@@ -31,6 +32,17 @@ final case class ScanResult(
   private def plural(n: Int, word: String): String = {
     val pluralForm = if (word == "class") "classes" else word + "s"
     if (n == 1) s"$n $word" else s"$n $pluralForm"
+  }
+
+  private def formatUnmatchedRuleEntry(r: MethodRule): String = {
+    val pattern = if (r.rawText.nonEmpty) r.rawText else "(pattern unavailable)"
+    val idStr = r.id.map(id => s"  id:$id").getOrElse("  (no id)")
+    val sourceStr = r.source match {
+      case GlobalSource(origin)              => s"  [global: $origin]"
+      case LocalSource(path) if path.nonEmpty => s"  [local: $path]"
+      case _                                 => ""
+    }
+    s"$pattern$idStr$sourceStr"
   }
 
   /** Print report to stdout. */
@@ -68,6 +80,13 @@ final case class ScanResult(
           out(s"[verify]     #${m.methodName}${m.descriptor}  excl:$exclStr → incl:$inclStr")
         }
       }
+      out("")
+    }
+
+    val unmatched = unmatchedRules
+    if (unmatched.nonEmpty) {
+      out(s"[verify] UNMATCHED RULES (${plural(unmatched.size, "rule")} matched zero methods):")
+      unmatched.foreach(r => out(s"[verify]   ${formatUnmatchedRuleEntry(r)}"))
       out("")
     }
 
@@ -112,6 +131,12 @@ final case class ScanResult(
       }
       lines += ""
     }
+    val unmatched = unmatchedRules
+    if (unmatched.nonEmpty) {
+      lines += s"UNMATCHED RULES (${plural(unmatched.size, "rule")} matched zero methods):"
+      unmatched.foreach(r => lines += s"  ${formatUnmatchedRuleEntry(r)}")
+      lines += ""
+    }
     lines += s"Summary: ${plural(classesScanned, "class")} scanned, ${plural(excluded.size, "method")} excluded, ${plural(rescued.size, "method")} rescued"
     lines.mkString("\n")
   }
@@ -137,13 +162,26 @@ final case class ScanResult(
     def rescuedEntry(m: MatchedMethod): String =
       s"""    {"class": ${str(m.fqcn)}, "method": ${str(m.methodName)}, "descriptor": ${str(m.descriptor)}, "exclusionRuleIds": ${strArr(m.exclusionIds)}, "inclusionRuleIds": ${strArr(m.inclusionIds)}}"""
 
-    val excBlock = if (excluded.isEmpty) "[]" else s"[\n${excluded.map(excludedEntry).mkString(",\n")}\n  ]"
-    val resBlock = if (rescued.isEmpty)  "[]" else s"[\n${rescued.map(rescuedEntry).mkString(",\n")}\n  ]"
+    def unmatchedEntry(r: MethodRule): String = {
+      val pattern = if (r.rawText.nonEmpty) r.rawText else ""
+      val idVal = r.id.map(str).getOrElse("\"\"")
+      val sourceVal = str(r.source match {
+        case GlobalSource(origin)               => s"global: $origin"
+        case LocalSource(path) if path.nonEmpty => s"local: $path"
+        case _                                  => ""
+      })
+      s"""    {"pattern": ${str(pattern)}, "id": $idVal, "source": $sourceVal}"""
+    }
+
+    val excBlock  = if (excluded.isEmpty) "[]" else s"[\n${excluded.map(excludedEntry).mkString(",\n")}\n  ]"
+    val resBlock  = if (rescued.isEmpty)  "[]" else s"[\n${rescued.map(rescuedEntry).mkString(",\n")}\n  ]"
+    val unmBlock  = if (unmatchedRules.isEmpty) "[]" else s"[\n${unmatchedRules.map(unmatchedEntry).mkString(",\n")}\n  ]"
 
     s"""{
   "classesScanned": $classesScanned,
   "excluded": $excBlock,
-  "rescued": $resBlock
+  "rescued": $resBlock,
+  "unmatchedRules": $unmBlock
 }"""
   }
 
@@ -161,6 +199,11 @@ final case class ScanResult(
     rescued.foreach { m =>
       sb.append(s"RESCUED,${cell(m.fqcn)},${cell(m.methodName)},${cell(m.descriptor)},${cell(m.exclusionIds.mkString("|"))},${cell(m.inclusionIds.mkString("|"))}\n")
     }
+    unmatchedRules.foreach { r =>
+      val pattern = if (r.rawText.nonEmpty) r.rawText else ""
+      val id      = r.id.getOrElse("")
+      sb.append(s"UNMATCHED_RULE,${cell(pattern)},,,${cell(id)},\n")
+    }
     sb.toString()
   }
 }
@@ -169,6 +212,9 @@ object VerifyScanner {
   def scan(classesDir: Path, rules: Seq[MethodRule]): ScanResult = {
     var classesScanned = 0
     val matchedMethods = mutable.ListBuffer.empty[MatchedMethod]
+    // Track every rule that matched at least one method during the scan.
+    // Uses reference identity via case-class equals (Pattern fields use reference equals).
+    val matchedRuleSet = mutable.HashSet.empty[MethodRule]
 
     using(Files.walk(classesDir)) { stream =>
       val it = stream.iterator().asScala
@@ -190,7 +236,11 @@ object VerifyScanner {
           override def visitMethod(access: Int, name: String, desc: String, signature: String, exceptions: Array[String]): MethodVisitor = {
             // Use RuleResolver to determine outcome
             val resolution = RuleResolver.resolve(rules, fqcnDots, name, desc, access)
-            
+
+            // Track every rule that matched this method (regardless of outcome).
+            matchedRuleSet ++= resolution.exclusions
+            matchedRuleSet ++= resolution.inclusions
+
             if (resolution.shouldExclude) {
               val exclusionIds = resolution.exclusions.flatMap(_.id)
               matchedMethods += MatchedMethod(fqcnDots, name, desc, Excluded, exclusionIds, Seq.empty, access)
@@ -207,6 +257,9 @@ object VerifyScanner {
       }
     }
 
-    ScanResult(classesScanned, matchedMethods.size, matchedMethods.toSeq)
+    // Rules that never produced a match and are not marked forward-compat.
+    val unmatchedRules = rules.filterNot(r => matchedRuleSet.contains(r) || r.forwardCompat)
+
+    ScanResult(classesScanned, matchedMethods.size, matchedMethods.toSeq, unmatchedRules)
   }
 }

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/VerifyScanner.scala
@@ -35,7 +35,7 @@ final case class ScanResult(
   }
 
   private def formatUnmatchedRuleEntry(r: MethodRule): String = {
-    val pattern = if (r.rawText.nonEmpty) r.rawText else "(pattern unavailable)"
+    val pattern = if (r.patternText.nonEmpty) r.patternText else "(pattern unavailable)"
     val idStr = r.id.map(id => s"  id:$id").getOrElse("  (no id)")
     val sourceStr = r.source match {
       case GlobalSource(origin)              => s"  [global: $origin]"
@@ -163,7 +163,7 @@ final case class ScanResult(
       s"""    {"class": ${str(m.fqcn)}, "method": ${str(m.methodName)}, "descriptor": ${str(m.descriptor)}, "exclusionRuleIds": ${strArr(m.exclusionIds)}, "inclusionRuleIds": ${strArr(m.inclusionIds)}}"""
 
     def unmatchedEntry(r: MethodRule): String = {
-      val pattern = if (r.rawText.nonEmpty) r.rawText else ""
+      val pattern = if (r.patternText.nonEmpty) r.patternText else ""
       val idVal = r.id.map(str).getOrElse("\"\"")
       val sourceVal = str(r.source match {
         case GlobalSource(origin)               => s"global: $origin"
@@ -200,7 +200,7 @@ final case class ScanResult(
       sb.append(s"RESCUED,${cell(m.fqcn)},${cell(m.methodName)},${cell(m.descriptor)},${cell(m.exclusionIds.mkString("|"))},${cell(m.inclusionIds.mkString("|"))}\n")
     }
     unmatchedRules.foreach { r =>
-      val pattern = if (r.rawText.nonEmpty) r.rawText else ""
+      val pattern = if (r.patternText.nonEmpty) r.patternText else ""
       val id      = r.id.getOrElse("")
       sb.append(s"UNMATCHED_RULE,${cell(pattern)},,,${cell(id)},\n")
     }

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
@@ -292,4 +292,45 @@ class CoverageRewriterCliSpec extends AnyFunSuite {
     assert(result.isDefined, "--report-format TXT without --report-file is allowed (normalised to txt)")
     assert(result.get.reportFormat == "txt", "TXT must be normalised to lowercase txt")
   }
+
+  // --- --error-on-unmatched ---
+
+  test("parse should accept --error-on-unmatched with --verify") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify", "--error-on-unmatched")
+    )
+    assert(result.isDefined)
+    assert(result.get.errorOnUnmatched)
+    assert(result.get.verify)
+  }
+
+  test("parse should reject --error-on-unmatched without --verify") {
+    val inDir  = newTempDir("jmf-in-")
+    val outDir = newTempDir("jmf-out-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--out", outDir.toString, "--global-rules", "rules.txt", "--error-on-unmatched")
+    )
+    assert(result.isEmpty, "--error-on-unmatched without --verify must be rejected")
+  }
+
+  test("parse should default errorOnUnmatched to false") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify")
+    )
+    assert(result.isDefined)
+    assert(!result.get.errorOnUnmatched)
+  }
+
+  test("parse should accept --error-on-unmatched combined with --report-file") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--error-on-unmatched", "--report-file", "/tmp/report.json", "--report-format", "json")
+    )
+    assert(result.isDefined)
+    assert(result.get.errorOnUnmatched)
+    assert(result.get.reportFormat == "json")
+  }
 }

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
@@ -318,4 +318,21 @@ class RulesLoadSpec extends AnyFunSuite {
     assert(rules(0).rawText == "com.example.*#copy(*) id:copy-rule")
     assert(rules(1).rawText == "+com.example.Config$#apply(*) id:keep-apply")
   }
+
+  // --- patternText field (selector-only, no tokens) ---
+
+  test("parseLine sets patternText to selector-only for exclude rule") {
+    val rule = Rules.parseLine("com.example.*#copy(*) id:case-copy").get
+    assert(rule.patternText == "com.example.*#copy(*)")
+  }
+
+  test("parseLine sets patternText with + prefix for include rule") {
+    val rule = Rules.parseLine("+com.example.*#apply(*) id:keep-apply").get
+    assert(rule.patternText == "+com.example.*#apply(*)")
+  }
+
+  test("parseLine sets patternText without tokens (id, forward-compat, flags)") {
+    val rule = Rules.parseLine("com.example.*#copy(*) forward-compat synthetic id:synth-copy").get
+    assert(rule.patternText == "com.example.*#copy(*)")
+  }
 }

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
@@ -255,4 +255,67 @@ class RulesLoadSpec extends AnyFunSuite {
     val rules = Rules.loadAll(Some(globalFile.toString), Some(localFile))
     assert(rules.size == 2)
   }
+
+  // --- forward-compat marker ---
+
+  test("forward-compat token sets forwardCompat = true") {
+    val rule = Rules.parseLine("com.example.*#copy(*) id:case-copy forward-compat").get
+    assert(rule.forwardCompat)
+    assert(rule.id.contains("case-copy"))
+  }
+
+  test("rule without forward-compat has forwardCompat = false by default") {
+    val rule = Rules.parseLine("com.example.*#copy(*) id:case-copy").get
+    assert(!rule.forwardCompat)
+  }
+
+  test("forward-compat can appear before other tokens") {
+    val rule = Rules.parseLine("com.example.*#copy(*) forward-compat id:case-copy").get
+    assert(rule.forwardCompat)
+    assert(rule.id.contains("case-copy"))
+  }
+
+  test("forward-compat can appear in combination with flags and predicates") {
+    val rule = Rules.parseLine("com.example.*#copy(*) synthetic forward-compat id:synth-copy").get
+    assert(rule.forwardCompat)
+    assert(rule.flags.contains("synthetic"))
+    assert(rule.id.contains("synth-copy"))
+  }
+
+  test("forward-compat is parsed for include rules") {
+    val rule = Rules.parseLine("+com.example.*#apply(*) forward-compat id:keep-apply").get
+    assert(rule.forwardCompat)
+    assert(rule.mode == Include)
+  }
+
+  // --- rawText field ---
+
+  test("parseLine stores original line text in rawText") {
+    val line = "com.example.*#copy(*) id:case-copy"
+    val rule = Rules.parseLine(line).get
+    assert(rule.rawText == line)
+  }
+
+  test("parseLine stores rawText including + prefix for include rules") {
+    val line = "+com.example.*#apply(*) id:keep-apply"
+    val rule = Rules.parseLine(line).get
+    assert(rule.rawText == line)
+  }
+
+  test("parseLine stores rawText with forward-compat token") {
+    val line = "com.example.*#copy(*) forward-compat id:case-copy"
+    val rule = Rules.parseLine(line).get
+    assert(rule.rawText == line)
+  }
+
+  test("load sets rawText for each rule from file") {
+    val file = write(tmpFile(), Seq(
+      "com.example.*#copy(*) id:copy-rule",
+      "+com.example.Config$#apply(*) id:keep-apply"
+    ))
+    val rules = Rules.load(file)
+    assert(rules.size == 2)
+    assert(rules(0).rawText == "com.example.*#copy(*) id:copy-rule")
+    assert(rules(1).rawText == "+com.example.Config$#apply(*) id:keep-apply")
+  }
 }

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
@@ -419,6 +419,7 @@ class VerifyScannerSpec extends AnyFunSuite {
     assert(json.contains("\"classesScanned\": 3"))
     assert(json.contains("\"excluded\": []"))
     assert(json.contains("\"rescued\": []"))
+    assert(json.contains("\"unmatchedRules\": []"), "empty unmatchedRules must produce an empty JSON array key")
   }
 
   test("formatReport csv has correct header and rows") {
@@ -574,6 +575,301 @@ class VerifyScannerSpec extends AnyFunSuite {
     assert(rows(0).contains("com.example.A") && rows(0).contains("aMethod"), "first data row must be A/aMethod")
     assert(rows(1).contains("com.example.A") && rows(1).contains("mMethod"), "second data row must be A/mMethod")
     assert(rows(2).contains("com.example.Z") && rows(2).contains("zMethod"), "third data row must be Z/zMethod")
+  }
+
+  // --- UNMATCHED RULES section ---
+
+  test("scan reports unmatched rules when no class matches the rule pattern") {
+    val dir = Files.createTempDirectory("verify-unmatched-")
+    try {
+      createTestClass(dir, "test.Existing", Seq(("doWork", "()V", Opcodes.ACC_PUBLIC)))
+
+      val rulesFile = tmpFile()
+      write(rulesFile, Seq(
+        "test.Existing#doWork(*) id:matched-rule",
+        "test.NonExistent#copy(*) id:unmatched-rule"
+      ))
+      val rules = Rules.load(rulesFile)
+
+      val result = VerifyScanner.scan(dir, rules)
+
+      assert(result.unmatchedRules.size == 1)
+      assert(result.unmatchedRules.head.id.contains("unmatched-rule"))
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  test("scan reports no unmatched rules when all rules match at least one method") {
+    val dir = Files.createTempDirectory("verify-all-matched-")
+    try {
+      createTestClass(dir, "test.Example", Seq(
+        ("copy", "()V", Opcodes.ACC_PUBLIC),
+        ("apply", "()V", Opcodes.ACC_PUBLIC)
+      ))
+
+      val rulesFile = tmpFile()
+      write(rulesFile, Seq(
+        "test.Example#copy(*) id:copy-rule",
+        "test.Example#apply(*) id:apply-rule"
+      ))
+      val rules = Rules.load(rulesFile)
+
+      val result = VerifyScanner.scan(dir, rules)
+
+      assert(result.unmatchedRules.isEmpty)
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  test("scan with empty rules list has empty unmatchedRules") {
+    val dir = Files.createTempDirectory("verify-empty-rules-")
+    try {
+      createTestClass(dir, "test.Foo", Seq(("bar", "()V", Opcodes.ACC_PUBLIC)))
+      val result = VerifyScanner.scan(dir, Seq.empty)
+      assert(result.unmatchedRules.isEmpty)
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  test("scan exempts forward-compat rules from unmatched reporting") {
+    val dir = Files.createTempDirectory("verify-fwd-compat-")
+    try {
+      createTestClass(dir, "test.Existing", Seq(("doWork", "()V", Opcodes.ACC_PUBLIC)))
+
+      val rulesFile = tmpFile()
+      write(rulesFile, Seq(
+        "test.FutureClass#copy(*) forward-compat id:future-rule",
+        "test.AnotherMissing#foo(*) id:plain-unmatched"
+      ))
+      val rules = Rules.load(rulesFile)
+
+      val result = VerifyScanner.scan(dir, rules)
+
+      // forward-compat rule is exempt; plain unmatched is reported
+      assert(result.unmatchedRules.size == 1)
+      assert(result.unmatchedRules.head.id.contains("plain-unmatched"))
+      assert(!result.unmatchedRules.exists(_.id.contains("future-rule")))
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  test("scan with all-forward-compat unmatched rules reports empty unmatchedRules") {
+    val dir = Files.createTempDirectory("verify-all-fwd-")
+    try {
+      createTestClass(dir, "test.Existing", Seq(("doWork", "()V", Opcodes.ACC_PUBLIC)))
+
+      val rulesFile = tmpFile()
+      write(rulesFile, Seq(
+        "test.FutureClassA#copy(*) forward-compat id:future-a",
+        "test.FutureClassB#apply(*) forward-compat id:future-b"
+      ))
+      val rules = Rules.load(rulesFile)
+
+      val result = VerifyScanner.scan(dir, rules)
+
+      assert(result.unmatchedRules.isEmpty)
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  test("include rule that matches a method is not reported as unmatched") {
+    val dir = Files.createTempDirectory("verify-include-matched-")
+    try {
+      createTestClass(dir, "test.Config$", Seq(
+        ("apply", "(Ljava/lang/Object;)Ltest/Config;", Opcodes.ACC_PUBLIC)
+      ))
+
+      val rulesFile = tmpFile()
+      write(rulesFile, Seq(
+        "test.*$#apply(*) id:comp-apply",
+        "+test.Config$#apply(*) id:keep-config-apply"
+      ))
+      val rules = Rules.load(rulesFile)
+
+      val result = VerifyScanner.scan(dir, rules)
+
+      // Both rules matched — neither should be in unmatchedRules
+      assert(result.unmatchedRules.isEmpty)
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  test("include rule that matches no methods is reported as unmatched") {
+    val dir = Files.createTempDirectory("verify-include-unmatched-")
+    try {
+      createTestClass(dir, "test.Foo", Seq(("bar", "()V", Opcodes.ACC_PUBLIC)))
+
+      val rulesFile = tmpFile()
+      write(rulesFile, Seq(
+        "+test.NonExistent$#apply(*) id:ghost-include"
+      ))
+      val rules = Rules.load(rulesFile)
+
+      val result = VerifyScanner.scan(dir, rules)
+
+      assert(result.unmatchedRules.size == 1)
+      assert(result.unmatchedRules.head.id.contains("ghost-include"))
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  // --- UNMATCHED RULES in printReport ---
+
+  test("printReport shows UNMATCHED RULES section when rules are unmatched") {
+    val rule = Rules.parseLine("test.Missing#copy(*) id:missing-copy").get
+    val result = ScanResult(1, 0, Seq.empty, Seq(rule))
+
+    val lines = scala.collection.mutable.ArrayBuffer[String]()
+    result.printReport(line => lines += line)
+
+    assert(lines.exists(_.contains("UNMATCHED RULES")))
+    assert(lines.exists(_.contains("missing-copy")))
+  }
+
+  test("printReport shows rawText in UNMATCHED RULES section") {
+    val rule = Rules.parseLine("test.Missing#copy(*) id:missing-copy").get
+    val result = ScanResult(1, 0, Seq.empty, Seq(rule))
+
+    val lines = scala.collection.mutable.ArrayBuffer[String]()
+    result.printReport(line => lines += line)
+
+    // rawText should appear in the unmatched section
+    assert(lines.exists(_.contains("test.Missing#copy(*)")))
+  }
+
+  test("printReport does not show UNMATCHED RULES section when all rules matched") {
+    val result = ScanResult(1, 0, Seq.empty, Seq.empty)
+
+    val lines = scala.collection.mutable.ArrayBuffer[String]()
+    result.printReport(line => lines += line)
+
+    assert(!lines.exists(_.contains("UNMATCHED RULES")))
+  }
+
+  test("printReport UNMATCHED RULES uses [verify] prefix") {
+    val rule = Rules.parseLine("test.X#foo(*) id:foo-rule").get
+    val result = ScanResult(0, 0, Seq.empty, Seq(rule))
+
+    val lines = scala.collection.mutable.ArrayBuffer[String]()
+    result.printReport(line => lines += line)
+
+    val unmatchedLine = lines.find(_.contains("UNMATCHED RULES")).getOrElse(fail("missing section header"))
+    assert(unmatchedLine.startsWith("[verify]"))
+  }
+
+  test("printReport includes forward-compat rules when explicitly placed in unmatchedRules") {
+    val rule = Rules.parseLine("test.Future#copy(*) forward-compat id:future-rule").get
+    // Normally forward-compat rules won't be in unmatchedRules (exempted by scan),
+    // but if explicitly passed in ScanResult, they should still display.
+    val result = ScanResult(0, 0, Seq.empty, Seq(rule))
+
+    val lines = scala.collection.mutable.ArrayBuffer[String]()
+    result.printReport(line => lines += line)
+
+    assert(lines.exists(_.contains("UNMATCHED RULES")))
+    assert(lines.exists(_.contains("future-rule")))
+  }
+
+  test("printReport shows source info for global rules in UNMATCHED section") {
+    val rule = Rules.parseLine("test.X#foo(*) id:foo-rule", GlobalSource("https://example.com/rules.txt")).get
+    val result = ScanResult(0, 0, Seq.empty, Seq(rule))
+
+    val lines = scala.collection.mutable.ArrayBuffer[String]()
+    result.printReport(line => lines += line)
+
+    val ruleEntry = lines.find(_.contains("foo-rule")).getOrElse(fail("rule entry missing"))
+    assert(ruleEntry.contains("global:") || ruleEntry.contains("[global"))
+  }
+
+  // --- UNMATCHED RULES in formatReport txt ---
+
+  test("formatReport txt includes UNMATCHED RULES section") {
+    val rule = Rules.parseLine("test.Missing#copy(*) id:missing-copy").get
+    val result = ScanResult(1, 0, Seq.empty, Seq(rule))
+    val txt = result.formatReport("txt")
+
+    assert(txt.contains("UNMATCHED RULES"))
+    assert(txt.contains("missing-copy"))
+    assert(!txt.contains("[verify]"), "txt format must not have [verify] prefix")
+  }
+
+  test("formatReport txt does not include UNMATCHED RULES section when empty") {
+    val result = ScanResult(1, 0, Seq.empty, Seq.empty)
+    val txt = result.formatReport("txt")
+    assert(!txt.contains("UNMATCHED RULES"))
+  }
+
+  // --- UNMATCHED RULES in formatReport json ---
+
+  test("formatReport json includes unmatchedRules array") {
+    val rule = Rules.parseLine("test.Missing#copy(*) id:missing-copy").get
+    val result = ScanResult(1, 0, Seq.empty, Seq(rule))
+    val json = result.formatReport("json")
+
+    assert(json.contains("\"unmatchedRules\""))
+    assert(json.contains("\"missing-copy\""))
+  }
+
+  test("formatReport json has empty unmatchedRules array when no unmatched rules") {
+    val result = ScanResult(1, 0, Seq.empty, Seq.empty)
+    val json = result.formatReport("json")
+
+    assert(json.contains("\"unmatchedRules\": []"))
+  }
+
+  test("formatReport json unmatched entry has pattern, id, and source fields") {
+    val rule = Rules.parseLine("test.Missing#copy(*) id:copy-rule", LocalSource("/path/rules.txt")).get
+    val result = ScanResult(1, 0, Seq.empty, Seq(rule))
+    val json = result.formatReport("json")
+
+    assert(json.contains("\"pattern\""))
+    assert(json.contains("\"id\""))
+    assert(json.contains("\"source\""))
+    assert(json.contains("copy-rule"))
+    assert(json.contains("test.Missing#copy(*)"))
+  }
+
+  test("formatReport json unmatched entry has empty id string when rule has no id") {
+    val rule = Rules.parseLine("test.Missing#copy(*)").get
+    val result = ScanResult(1, 0, Seq.empty, Seq(rule))
+    val json = result.formatReport("json")
+
+    // id field should be present with empty value
+    assert(json.contains("\"id\": \"\""))
+  }
+
+  // --- UNMATCHED RULES in formatReport csv ---
+
+  test("formatReport csv includes UNMATCHED_RULE rows") {
+    val rule = Rules.parseLine("test.Missing#copy(*) id:missing-copy").get
+    val result = ScanResult(1, 0, Seq.empty, Seq(rule))
+    val csv = result.formatReport("csv")
+
+    assert(csv.contains("UNMATCHED_RULE"))
+    assert(csv.contains("missing-copy"))
+  }
+
+  test("formatReport csv has no UNMATCHED_RULE rows when no unmatched rules") {
+    val result = ScanResult(1, 0, Seq.empty, Seq.empty)
+    val csv = result.formatReport("csv")
+    assert(!csv.contains("UNMATCHED_RULE"))
+  }
+
+  test("formatReport csv UNMATCHED_RULE row has rawText in class column and id in exclusionRuleIds column") {
+    val rule = Rules.parseLine("test.Missing#copy(*) id:missing-copy").get
+    val result = ScanResult(1, 0, Seq.empty, Seq(rule))
+    val csv = result.formatReport("csv")
+    val rows = csv.split("\n")
+    val unmatchedRow = rows.find(_.startsWith("UNMATCHED_RULE")).getOrElse(fail("no UNMATCHED_RULE row"))
+    assert(unmatchedRow.contains("test.Missing#copy(*)"))
+    assert(unmatchedRow.contains("missing-copy"))
   }
 
   // Helper to delete directory recursively

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/VerifyScannerSpec.scala
@@ -733,15 +733,17 @@ class VerifyScannerSpec extends AnyFunSuite {
     assert(lines.exists(_.contains("missing-copy")))
   }
 
-  test("printReport shows rawText in UNMATCHED RULES section") {
+  test("printReport shows selector pattern in UNMATCHED RULES section") {
     val rule = Rules.parseLine("test.Missing#copy(*) id:missing-copy").get
     val result = ScanResult(1, 0, Seq.empty, Seq(rule))
 
     val lines = scala.collection.mutable.ArrayBuffer[String]()
     result.printReport(line => lines += line)
 
-    // rawText should appear in the unmatched section
+    // selector (without tokens) must appear
     assert(lines.exists(_.contains("test.Missing#copy(*)")))
+    // id must not be duplicated — patternText contains no id: token
+    assert(!lines.exists(_.contains("id:missing-copy  id:missing-copy")), "id token must not appear twice in one line")
   }
 
   test("printReport does not show UNMATCHED RULES section when all rules matched") {
@@ -833,7 +835,9 @@ class VerifyScannerSpec extends AnyFunSuite {
     assert(json.contains("\"id\""))
     assert(json.contains("\"source\""))
     assert(json.contains("copy-rule"))
-    assert(json.contains("test.Missing#copy(*)"))
+    // pattern must be selector-only (no id: token — that would duplicate the separate id field)
+    assert(json.contains("\"test.Missing#copy(*)\""), "pattern value must be selector-only")
+    assert(!json.contains("\"test.Missing#copy(*) id:copy-rule\""), "pattern must not include id: token")
   }
 
   test("formatReport json unmatched entry has empty id string when rule has no id") {
@@ -862,13 +866,15 @@ class VerifyScannerSpec extends AnyFunSuite {
     assert(!csv.contains("UNMATCHED_RULE"))
   }
 
-  test("formatReport csv UNMATCHED_RULE row has rawText in class column and id in exclusionRuleIds column") {
+  test("formatReport csv UNMATCHED_RULE row has selector pattern in class column and id in exclusionRuleIds column") {
     val rule = Rules.parseLine("test.Missing#copy(*) id:missing-copy").get
     val result = ScanResult(1, 0, Seq.empty, Seq(rule))
     val csv = result.formatReport("csv")
     val rows = csv.split("\n")
     val unmatchedRow = rows.find(_.startsWith("UNMATCHED_RULE")).getOrElse(fail("no UNMATCHED_RULE row"))
+    // class column must hold selector-only (no id: token)
     assert(unmatchedRow.contains("test.Missing#copy(*)"))
+    assert(!unmatchedRow.contains("test.Missing#copy(*) id:missing-copy"), "id: token must not appear in selector column")
     assert(unmatchedRow.contains("missing-copy"))
   }
 


### PR DESCRIPTION
- Introduced `--error-on-unmatched` flag to exit with a non-zero status when rules match zero methods.
- Enhanced `CliConfig` to include `errorOnUnmatched` parameter.
- Updated `CoverageRewriter` to handle unmatched rules and report them accordingly.
- Added `forwardCompat` field to `MethodRule` to exempt certain rules from unmatched reporting.
- Implemented logic in `VerifyScanner` to track unmatched rules and filter out forward-compatible ones.
- Enhanced report formatting to include unmatched rules in various output formats (txt, json, csv).
- Added integration tests to validate the new functionality, ensuring unmatched rules are reported correctly.
- Updated existing tests to cover new behavior and ensure backward compatibility.

Release Notes:
- New "unmatched rules" report in --verify mode that lists rules which matched zero methods
in the scanned class directory.


Closes #61 
