### PR TITLE
feat: implement --strict flag to enforce id: label requirement for rules

### DIFF
--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -29,7 +29,9 @@ Full syntax reference, authoring guide, and diagnostic workflows for jacoco-meth
 3. Keep rules narrow (by package), prefer flags (`synthetic`/`bridge`) for compiler artifacts,
    and add `id:` labels so logs are readable.
 4. Use `--verify` mode to confirm rules match what you expect before committing.
-5. **Prefer include rules over commenting out globals.** When a broad global accidentally matches
+5. Add `--strict` to your CI build command (CLI) to fail fast when rules are missing `id:` labels.
+   (The sbt and Maven plugins do not yet expose `--strict` as a configuration key.)
+6. **Prefer include rules over commenting out globals.** When a broad global accidentally matches
    a method with real logic, keep the global active and add a `+` include rule to rescue that
    specific method. Commenting out the global loses filtering for *all* other matching methods.
    See [Exclude and Include Rules](#exclude-and-include-rules).
@@ -65,7 +67,7 @@ RIGHT: *#*(*) synthetic    (space separates flag from descriptor)
 **PREDICATES** — Space-separated key:value pairs. Optional.
 
 - `ret:<glob>` — Match return type only (e.g., `ret:V`, `ret:Lcom/example/*;`)
-- `id:<string>` — Identifier shown in logs/reports (required for traceability)
+- `id:<string>` — Identifier shown in logs/reports (required for traceability; empty value treated as absent)
 - `name-contains:<s>` — Method name must contain `<s>`
 - `name-starts:<s>` — Method name must start with `<s>`
 - `name-ends:<s>` — Method name must end with `<s>`
@@ -166,7 +168,18 @@ WRONG: *#make(*) ret:Lcom/example/model/Id   (missing semicolon)
 RIGHT: *#make(*) ret:Lcom/example/model/Id;  (semicolon required)
 ```
 
-**5.** Every rule should include `id:<label>` for traceability in logs.
+**5.** Every rule should include `id:<label>` for traceability in logs. Rules without `id:` emit
+a `[warn]` message at load time (showing source file and line number) **regardless of whether
+`--strict` is set**. To enforce `id:` as a hard CI requirement, pass `--strict` to the CLI —
+any unlabelled rule causes a non-zero exit:
+
+```bash
+java -cp ... io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --verify \
+  --in target/classes \
+  --local-rules jmf-rules.txt \
+  --strict
+```
 
 **6.** `#` is both the comment marker (start of line) and FQCN/method separator. Inline comments
 after rules are harmless but can be confusing. Best practice: use dedicated comment lines above the rule.
@@ -538,6 +551,22 @@ java -cp ... io.moranaapps.jacocomethodfilter.CoverageRewriter \
 
 Exit code is `1` when any unmatched rules exist; `0` when all rules matched.
 
+To enforce that every rule has an `id:` label, add `--strict`:
+
+```bash
+java -cp ... io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --verify \
+  --in target/classes \
+  --local-rules jmf-rules.txt \
+  --strict
+```
+
+Exit code is `1` when any rules lack an `id:` label; `0` when all rules are labelled.
+Both `--error-on-unmatched` and `--strict` can be combined. When combined, the `--strict`
+check runs first; if any rules lack `id:`, the process aborts before scanning for unmatched
+rules. Rules without `id:` also emit a `[warn]` message at load time (regardless of `--strict`),
+making them visible in non-strict runs.
+
 ### Forward-Compatible Rules
 
 Some rules are intentionally written to target classes present in a *production* build but absent
@@ -672,6 +701,7 @@ globally and rescue lazy vals with real logic:
 | `--dry-run` | No | Only print matches; do not modify classes |
 | `--verify` | No | Read-only scan: list all methods that would be excluded by rules |
 | `--error-on-unmatched` | No | Exit non-zero if any rules matched zero methods (requires `--verify`) |
+| `--strict` | No | Exit non-zero if any rules have no `id:` label |
 | `--report-file <path>` | No | Write the filtered-methods report to this file |
 | `--report-format <fmt>` | No | Report format: `txt` (default), `json`, or `csv` (requires `--report-file`) |
 

--- a/integration-tests/test-cli-strict.sh
+++ b/integration-tests/test-cli-strict.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Test: --strict flag — exits non-zero when any rules have no id: label.
+#
+# Covers:
+#   1. Rules without id: produce [warn] output at load time (no --strict).
+#   2. Rules with id: produce no [warn] output.
+#   3. --strict exits non-zero when any rules lack id: label.
+#   4. --strict exits zero when all rules have id: labels.
+#   5. --strict works in rewrite mode (not only --verify).
+#   6. Warning message includes source file path and line number.
+#
+# Prerequisite: rewriter-core published locally (run 'sbt publishLocal' first).
+# ---------------------------------------------------------------------------
+source "$(dirname "$0")/helpers.sh"
+
+TEST_NAME="cli-strict"
+info "Running: $TEST_NAME"
+
+# ── Set up project ─────────────────────────────────────────────────────────
+cp -R "$REPO_ROOT/integration-tests/fixtures/sbt-basic" "$WORK_DIR/project"
+cp -R "$REPO_ROOT/examples/sbt-basic/src"               "$WORK_DIR/project/src"
+cd "$WORK_DIR/project"
+
+run_cmd "$TEST_NAME — compiling project" sbt compile
+run_cmd "$TEST_NAME — exporting classpath" sbt "export runtime:dependencyClasspath"
+
+assert_dir_not_empty "target/scala-2.12/classes" \
+  "$TEST_NAME — compiled classes exist"
+
+# ── Locate JARs ────────────────────────────────────────────────────────────
+CORE_JAR=$(
+  find ~/.ivy2/local/io.github.moranaapps/jacoco-method-filter-core_2.12 \
+    -name "jacoco-method-filter-core_2.12.jar" 2>/dev/null | \
+  while IFS= read -r f; do
+    timestamp=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null)
+    printf '%s\t%s\n' "$timestamp" "$f"
+  done | sort -rn | head -1 | cut -f2- || true
+)
+
+SCALA_LIB=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "scala-library-2.12*.jar" 2>/dev/null | head -1 || true)
+ASM_JAR=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "asm-9.*.jar" 2>/dev/null | sort -V | tail -1 || true)
+ASM_COMMONS_JAR=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "asm-commons-9.*.jar" 2>/dev/null | sort -V | tail -1 || true)
+SCOPT_JAR=$(find ~/.cache/coursier ~/Library/Caches/Coursier -name "scopt_2.12-*.jar"        2>/dev/null | head -1 || true)
+
+if [[ -z "$CORE_JAR" || ! -f "$CORE_JAR" ]]; then
+  fail "$TEST_NAME — core JAR not found in ~/.ivy2/local (run 'sbt publishLocal' first)"
+fi
+if [[ -z "$SCALA_LIB" || ! -f "$SCALA_LIB" ]]; then
+  fail "$TEST_NAME — Scala library not found in Coursier cache"
+fi
+if [[ -z "$ASM_JAR" || ! -f "$ASM_JAR" ]]; then
+  fail "$TEST_NAME — ASM JAR not found in Coursier cache"
+fi
+if [[ -z "$SCOPT_JAR" || ! -f "$SCOPT_JAR" ]]; then
+  fail "$TEST_NAME — scopt JAR not found in Coursier cache"
+fi
+
+CP="$CORE_JAR:$SCALA_LIB:$ASM_JAR:$SCOPT_JAR"
+if [[ -n "$ASM_COMMONS_JAR" && -f "$ASM_COMMONS_JAR" ]]; then
+  CP="$CP:$ASM_COMMONS_JAR"
+fi
+
+# ── Helper: run CLI verify with a given rules file (does not fail on non-zero) ──
+run_verify() {
+  local rules_file="$1"; shift
+  java -cp "$CP" io.moranaapps.jacocomethodfilter.CoverageRewriter \
+    --verify \
+    --in target/scala-2.12/classes \
+    --local-rules "$rules_file" "$@" 2>&1 || true
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 1 — Unlabelled rule emits [warn] at load time (without --strict)
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 1: unlabelled rule emits [warn] at load time"
+
+cat > rules-no-id.txt <<'EOF'
+# Rule without id: label — should trigger a [warn]
+*Calculator#copy(*)
+EOF
+
+OUTPUT1=$(run_verify rules-no-id.txt)
+echo "─── output ───"
+echo "$OUTPUT1"
+echo "─── end output ───"
+
+echo "$OUTPUT1" | grep -q "\[warn\]" || \
+  fail "$TEST_NAME — test 1: expected [warn] in output for unlabelled rule"
+
+echo "$OUTPUT1" | grep -q "no id: label" || \
+  fail "$TEST_NAME — test 1: expected 'no id: label' in [warn] message"
+
+echo "$OUTPUT1" | grep -q "rules-no-id.txt" || \
+  fail "$TEST_NAME — test 1: expected source file name in [warn] message"
+
+pass "$TEST_NAME — test 1: [warn] emitted for unlabelled rule"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 2 — Labelled rules produce no [warn]
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 2: labelled rules produce no [warn]"
+
+cat > rules-with-ids.txt <<'EOF'
+*Calculator#copy(*) id:calc-copy
+*Calculator#equals(*) id:calc-equals
+EOF
+
+OUTPUT2=$(run_verify rules-with-ids.txt)
+echo "─── output ───"
+echo "$OUTPUT2"
+echo "─── end output ───"
+
+if echo "$OUTPUT2" | grep -q "\[warn\]"; then
+  fail "$TEST_NAME — test 2: unexpected [warn] in output when all rules have id: labels"
+fi
+
+pass "$TEST_NAME — test 2: no [warn] when all rules are labelled"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 3 — --strict exits non-zero when any rules lack id: label
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 3: --strict exits non-zero when unlabelled rules present"
+
+EXIT_CODE3=0
+OUTPUT3=$(java -cp "$CP" io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --verify \
+  --in target/scala-2.12/classes \
+  --local-rules rules-no-id.txt \
+  --strict 2>&1) || EXIT_CODE3=$?
+
+echo "─── output ───"
+echo "$OUTPUT3"
+echo "─── end output (exit $EXIT_CODE3) ───"
+
+if [[ $EXIT_CODE3 -eq 0 ]]; then
+  fail "$TEST_NAME — test 3: --strict must exit non-zero when unlabelled rules exist (got 0)"
+fi
+
+echo "$OUTPUT3" | grep -q "\[error\]" || \
+  fail "$TEST_NAME — test 3: expected [error] message when --strict aborts"
+
+echo "$OUTPUT3" | grep -q "no id: label" || \
+  fail "$TEST_NAME — test 3: expected 'no id: label' in [error] message"
+
+pass "$TEST_NAME — test 3: --strict exits non-zero ($EXIT_CODE3)"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 4 — --strict exits zero when all rules have id: labels
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 4: --strict exits zero when all rules labelled"
+
+EXIT_CODE4=0
+OUTPUT4=$(java -cp "$CP" io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --verify \
+  --in target/scala-2.12/classes \
+  --local-rules rules-with-ids.txt \
+  --strict 2>&1) || EXIT_CODE4=$?
+
+echo "─── output ───"
+echo "$OUTPUT4"
+echo "─── end output (exit $EXIT_CODE4) ───"
+
+if [[ $EXIT_CODE4 -ne 0 ]]; then
+  fail "$TEST_NAME — test 4: --strict must exit zero when all rules have id: labels (got $EXIT_CODE4)"
+fi
+
+if echo "$OUTPUT4" | grep -q "\[error\]"; then
+  fail "$TEST_NAME — test 4: unexpected [error] when all rules are labelled"
+fi
+
+pass "$TEST_NAME — test 4: --strict exits zero when all rules labelled"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 5 — --strict works in rewrite mode (not only --verify)
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 5: --strict works in rewrite mode"
+
+STRICT_OUT_DIR="$WORK_DIR/out-strict"
+EXIT_CODE5=0
+OUTPUT5=$(java -cp "$CP" io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --in target/scala-2.12/classes \
+  --out "$STRICT_OUT_DIR" \
+  --local-rules rules-no-id.txt \
+  --strict 2>&1) || EXIT_CODE5=$?
+
+echo "─── output ───"
+echo "$OUTPUT5"
+echo "─── end output (exit $EXIT_CODE5) ───"
+
+if [[ $EXIT_CODE5 -eq 0 ]]; then
+  fail "$TEST_NAME — test 5: --strict in rewrite mode must exit non-zero when unlabelled rules exist"
+fi
+
+if [[ -d "$STRICT_OUT_DIR" ]]; then
+  fail "$TEST_NAME — test 5: output directory must NOT be created when --strict aborts early"
+fi
+
+pass "$TEST_NAME — test 5: --strict exits non-zero in rewrite mode ($EXIT_CODE5)"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 6 — Warning includes source file path and line number
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 6: [warn] includes file path and line number"
+
+cat > rules-mixed.txt <<'EOF'
+# line 1: comment (skipped)
+*Calculator#copy(*) id:calc-copy
+*Calculator#hashCode(*)
+EOF
+
+OUTPUT6=$(run_verify rules-mixed.txt)
+echo "─── output ───"
+echo "$OUTPUT6"
+echo "─── end output ───"
+
+echo "$OUTPUT6" | grep -q "\[warn\]" || \
+  fail "$TEST_NAME — test 6: expected [warn] for unlabelled rule on line 3"
+
+echo "$OUTPUT6" | grep "\[warn\]" | grep -q "line 3" || \
+  fail "$TEST_NAME — test 6: expected 'line 3' in [warn] message"
+
+echo "$OUTPUT6" | grep "\[warn\]" | grep -q "rules-mixed.txt" || \
+  fail "$TEST_NAME — test 6: expected file name in [warn] message"
+
+pass "$TEST_NAME — test 6: [warn] contains file path and line number"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 7 — --strict with mixed labelled/unlabelled: reports count
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 7: --strict reports count of unlabelled rules"
+
+EXIT_CODE7=0
+OUTPUT7=$(java -cp "$CP" io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --verify \
+  --in target/scala-2.12/classes \
+  --local-rules rules-mixed.txt \
+  --strict 2>&1) || EXIT_CODE7=$?
+
+echo "─── output ───"
+echo "$OUTPUT7"
+echo "─── end output (exit $EXIT_CODE7) ───"
+
+if [[ $EXIT_CODE7 -eq 0 ]]; then
+  fail "$TEST_NAME — test 7: --strict must exit non-zero for mixed rules"
+fi
+
+echo "$OUTPUT7" | grep -q "1 rule(s) have no id:" || \
+  fail "$TEST_NAME — test 7: expected count '1 rule(s)' in [error] message"
+
+pass "$TEST_NAME — test 7: --strict reports correct count of unlabelled rules"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test 8 — Combined --strict AND --error-on-unmatched: strict check runs first
+# ═══════════════════════════════════════════════════════════════════════════
+info "$TEST_NAME — test 8: --strict takes precedence when combined with --error-on-unmatched"
+
+# Both conditions true: unlabelled rule (no id) + unmatched rule (class does not exist)
+cat > rules-unlabelled-unmatched.txt <<'EOF'
+*com.example.DoesNotExist#copy(*)
+EOF
+
+EXIT_CODE8=0
+OUTPUT8=$(java -cp "$CP" io.moranaapps.jacocomethodfilter.CoverageRewriter \
+  --verify \
+  --in target/scala-2.12/classes \
+  --local-rules rules-unlabelled-unmatched.txt \
+  --strict \
+  --error-on-unmatched 2>&1) || EXIT_CODE8=$?
+
+echo "─── output ───"
+echo "$OUTPUT8"
+echo "─── end output (exit $EXIT_CODE8) ───"
+
+if [[ $EXIT_CODE8 -eq 0 ]]; then
+  fail "$TEST_NAME — test 8: must exit non-zero when both --strict and --error-on-unmatched conditions fail"
+fi
+
+echo "$OUTPUT8" | grep -q "no id: label" || \
+  fail "$TEST_NAME — test 8: expected 'no id: label' abort message (--strict check runs first)"
+
+pass "$TEST_NAME — test 8: combined --strict and --error-on-unmatched exits non-zero"
+
+pass "$TEST_NAME"

--- a/jmf-rules.template.txt
+++ b/jmf-rules.template.txt
@@ -10,6 +10,9 @@
 # 1) Review the GLOBAL RULES below — they cover compiler-generated boilerplate.
 # 2) Add project-specific patterns in the PROJECT RULES section.
 # 3) Keep rules narrow; add id: labels so logs are readable.
+#    Every rule must have an id:<label>. Unlabelled rules emit a [warn] at load
+#    time. CLI users: pass --strict to enforce id: as a hard CI requirement.
+#    (Sbt/Maven plugins do not yet expose --strict as a configuration key.)
 # 4) Use --verify mode to confirm rules match before committing.
 #
 # ─────────────────────────────────────────────────────────────────────────────

--- a/jmf-rules.template.txt
+++ b/jmf-rules.template.txt
@@ -12,7 +12,7 @@
 # 3) Keep rules narrow; add id: labels so logs are readable.
 #    Every rule must have an id:<label>. Unlabelled rules emit a [warn] at load
 #    time. CLI users: pass --strict to enforce id: as a hard CI requirement.
-#    (Sbt/Maven plugins do not yet expose --strict as a configuration key.)
+#    (sbt/Maven plugins do not yet expose --strict as a configuration key.)
 # 4) Use --verify mode to confirm rules match before committing.
 #
 # ─────────────────────────────────────────────────────────────────────────────

--- a/maven-plugin/src/main/resources/jmf-rules.template.txt
+++ b/maven-plugin/src/main/resources/jmf-rules.template.txt
@@ -10,6 +10,9 @@
 # 1) Review the GLOBAL RULES below — they cover compiler-generated boilerplate.
 # 2) Add project-specific patterns in the PROJECT RULES section.
 # 3) Keep rules narrow; add id: labels so logs are readable.
+#    Every rule must have an id:<label>. Unlabelled rules emit a [warn] at load
+#    time. CLI users: pass --strict to enforce id: as a hard CI requirement.
+#    (Sbt/Maven plugins do not yet expose --strict as a configuration key.)
 # 4) Use --verify mode to confirm rules match before committing.
 #
 # ─────────────────────────────────────────────────────────────────────────────

--- a/maven-plugin/src/main/resources/jmf-rules.template.txt
+++ b/maven-plugin/src/main/resources/jmf-rules.template.txt
@@ -12,7 +12,7 @@
 # 3) Keep rules narrow; add id: labels so logs are readable.
 #    Every rule must have an id:<label>. Unlabelled rules emit a [warn] at load
 #    time. CLI users: pass --strict to enforce id: as a hard CI requirement.
-#    (Sbt/Maven plugins do not yet expose --strict as a configuration key.)
+#    (sbt/Maven plugins do not yet expose --strict as a configuration key.)
 # 4) Use --verify mode to confirm rules match before committing.
 #
 # ─────────────────────────────────────────────────────────────────────────────

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriter.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriter.scala
@@ -53,11 +53,7 @@ object CoverageRewriter {
     val rules = Rules.loadAll(cfg.globalRules, cfg.localRules)
     println(s"[info] Loaded ${rules.size} rule(s) from ${rulesSummary(cfg)}")
 
-    val unlabelledCount = rules.count(_.id.isEmpty)
-    if (unlabelledCount > 0 && cfg.strict) {
-      println(s"[error] Aborting: $unlabelledCount rule(s) have no id: label (--strict is set).")
-      sys.exit(1)
-    }
+    abortIfUnlabelled(rules, cfg)
 
     Files.createDirectories(outPath)
     var files = 0
@@ -83,11 +79,7 @@ object CoverageRewriter {
   private def verify(cfg: CliConfig): Unit = {
     val rules = Rules.loadAll(cfg.globalRules, cfg.localRules)
 
-    val unlabelledCount = rules.count(_.id.isEmpty)
-    if (unlabelledCount > 0 && cfg.strict) {
-      println(s"[error] Aborting: $unlabelledCount rule(s) have no id: label (--strict is set).")
-      sys.exit(1)
-    }
+    abortIfUnlabelled(rules, cfg)
 
     println(s"[verify] Active rules from ${rulesSummary(cfg)}:")
     printRulesListing(rules)
@@ -114,6 +106,16 @@ object CoverageRewriter {
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
+
+  private def abortIfUnlabelled(rules: Seq[MethodRule], cfg: CliConfig): Unit = {
+    if (cfg.strict) {
+      val unlabelledCount = rules.count(_.id.isEmpty)
+      if (unlabelledCount > 0) {
+        println(s"[error] Aborting: $unlabelledCount rule(s) have no id: label (--strict is set).")
+        sys.exit(1)
+      }
+    }
+  }
 
   private def writeReportFile(path: Path, content: String): Unit = {
     Option(path.getParent).foreach(Files.createDirectories(_))

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriter.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriter.scala
@@ -16,6 +16,7 @@ import java.nio.file.{Files, Path, Paths}
   * @param reportFile Optional path to write the filtered-methods report (txt/json/csv)
   * @param reportFormat Report format: txt (default), json, or csv
   * @param errorOnUnmatched If true, exit non-zero when any rules matched zero methods (requires verify mode)
+  * @param strict If true, exit non-zero when any rules have no id: label
   */
 private[jacocomethodfilter] final case class CliConfig(
   in: Path = Paths.get("."),
@@ -26,7 +27,8 @@ private[jacocomethodfilter] final case class CliConfig(
   verify: Boolean = false,
   reportFile: Option[Path] = None,
   reportFormat: String = "txt",
-  errorOnUnmatched: Boolean = false
+  errorOnUnmatched: Boolean = false,
+  strict: Boolean = false
 )
 
 object CoverageRewriter {
@@ -51,6 +53,12 @@ object CoverageRewriter {
     val rules = Rules.loadAll(cfg.globalRules, cfg.localRules)
     println(s"[info] Loaded ${rules.size} rule(s) from ${rulesSummary(cfg)}")
 
+    val unlabelledCount = rules.count(_.id.isEmpty)
+    if (unlabelledCount > 0 && cfg.strict) {
+      println(s"[error] Aborting: $unlabelledCount rule(s) have no id: label (--strict is set).")
+      sys.exit(1)
+    }
+
     Files.createDirectories(outPath)
     var files = 0
     var marked = 0
@@ -74,6 +82,12 @@ object CoverageRewriter {
 
   private def verify(cfg: CliConfig): Unit = {
     val rules = Rules.loadAll(cfg.globalRules, cfg.localRules)
+
+    val unlabelledCount = rules.count(_.id.isEmpty)
+    if (unlabelledCount > 0 && cfg.strict) {
+      println(s"[error] Aborting: $unlabelledCount rule(s) have no id: label (--strict is set).")
+      sys.exit(1)
+    }
 
     println(s"[verify] Active rules from ${rulesSummary(cfg)}:")
     printRulesListing(rules)

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCli.scala
@@ -49,6 +49,10 @@ private[jacocomethodfilter] object CoverageRewriterCli {
         .action((_, c) => c.copy(errorOnUnmatched = true))
         .text("Exit non-zero if any rules matched zero methods (requires --verify)")
 
+      opt[Unit]("strict")
+        .action((_, c) => c.copy(strict = true))
+        .text("Exit non-zero if any rules have no id: label (unlabelled-rule enforcement)")
+
       opt[String]("report-file")
         .optional()
         .action((v, c) => c.copy(reportFile = Some(Paths.get(v))))

--- a/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/Rules.scala
+++ b/rewriter-core/src/main/scala/io/moranaapps/jacocomethodfilter/Rules.scala
@@ -71,10 +71,10 @@ object Rules {
       throw new java.nio.file.NoSuchFileException(path.toString, null, "Rules file not found")
     val lines = Files.readAllLines(path).asScala.toVector
     val source = LocalSource(path.toString)
-    lines.flatMap(line => parseLine(line, source))
+    lines.zipWithIndex.flatMap { case (line, idx) => parseLine(line, source, idx + 1) }
   }
 
-  private[jacocomethodfilter] def parseLine(raw: String, source: RuleSource = LocalSource("")): Option[MethodRule] = {
+  private[jacocomethodfilter] def parseLine(raw: String, source: RuleSource = LocalSource(""), lineNum: Int = -1): Option[MethodRule] = {
     val line = raw.trim
     if (line.isEmpty || line.startsWith("#")) return None
 
@@ -126,7 +126,7 @@ object Rules {
       case t @ ("public" | "protected" | "private" | "synthetic" | "bridge" | "static" | "abstract") =>
         flags += t
       case kv if kv.startsWith("ret:")            => retGlob      = Some(Selectors.globToRegex(kv.stripPrefix("ret:")))
-      case kv if kv.startsWith("id:")             => id           = Some(kv.stripPrefix("id:"))
+      case kv if kv.startsWith("id:")             => id           = Some(kv.stripPrefix("id:")).filter(_.nonEmpty)
       case kv if kv.startsWith("name-contains:")  => nameContains = Some(kv.stripPrefix("name-contains:"))
       case kv if kv.startsWith("name-starts:")    => nameStarts   = Some(kv.stripPrefix("name-starts:"))
       case kv if kv.startsWith("name-ends:")      => nameEnds     = Some(kv.stripPrefix("name-ends:"))
@@ -145,6 +145,15 @@ object Rules {
     ensureNoRegex(clsSel,    "class")
     ensureNoRegex(methodSel, "method")
     ensureNoRegex(descSel,   "descriptor")
+
+    if (id.isEmpty) {
+      val lineInfo  = if (lineNum > 0) s" line $lineNum" else ""
+      val sourceStr = source match {
+        case LocalSource(p)  => if (p.nonEmpty) p else "<unknown>"
+        case GlobalSource(o) => o
+      }
+      println(s"[warn] $sourceStr$lineInfo: rule has no id: label ($patternText). Add id:<label> for traceability.")
+    }
 
     Some(MethodRule(
       cls           = Selectors.globToRegex(clsSel),
@@ -253,7 +262,7 @@ object Rules {
           lines += line
           line = reader.readLine()
         }
-        lines.toVector.flatMap(line => parseLine(line, ruleSource))
+        lines.toVector.zipWithIndex.flatMap { case (rawLine, idx) => parseLine(rawLine, ruleSource, idx + 1) }
       } finally {
         reader.close()
       }
@@ -266,7 +275,7 @@ object Rules {
     if (!Files.exists(path))
       throw new java.nio.file.NoSuchFileException(path.toString, null, "Rules file not found")
     val lines = Files.readAllLines(path).asScala.toVector
-    lines.flatMap(line => parseLine(line, ruleSource))
+    lines.zipWithIndex.flatMap { case (line, idx) => parseLine(line, ruleSource, idx + 1) }
   }
 
   /**

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/CoverageRewriterCliSpec.scala
@@ -333,4 +333,46 @@ class CoverageRewriterCliSpec extends AnyFunSuite {
     assert(result.get.errorOnUnmatched)
     assert(result.get.reportFormat == "json")
   }
+
+  // --- --strict ---
+
+  test("parse should accept --strict flag") {
+    val inDir  = newTempDir("jmf-in-")
+    val outDir = newTempDir("jmf-out-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--out", outDir.toString, "--global-rules", "rules.txt", "--strict")
+    )
+    assert(result.isDefined)
+    assert(result.get.strict)
+  }
+
+  test("parse should default strict to false") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify")
+    )
+    assert(result.isDefined)
+    assert(!result.get.strict)
+  }
+
+  test("parse should accept --strict with --verify") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify", "--strict")
+    )
+    assert(result.isDefined)
+    assert(result.get.strict)
+    assert(result.get.verify)
+  }
+
+  test("parse should accept --strict combined with --error-on-unmatched") {
+    val inDir = newTempDir("jmf-in-")
+    val result = CoverageRewriterCli.parse(
+      Array("--in", inDir.toString, "--global-rules", "rules.txt", "--verify",
+        "--strict", "--error-on-unmatched")
+    )
+    assert(result.isDefined)
+    assert(result.get.strict)
+    assert(result.get.errorOnUnmatched)
+  }
 }

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
@@ -354,7 +354,8 @@ class RulesLoadSpec extends AnyFunSuite {
     val file = write(tmpFile(), Seq("com.example.*#copy(*) id:my-rule"))
     val out  = new java.io.ByteArrayOutputStream()
     Console.withOut(out) { Rules.load(file) }
-    assert(out.toString.isEmpty, s"Expected no output, got: ${out.toString}")
+    val warnLines = out.toString.linesIterator.filter(l => l.contains(file.toString) && l.contains("[warn]")).mkString
+    assert(warnLines.isEmpty, s"Expected no [warn] for $file, got: $warnLines")
   }
 
   test("warning includes source file path and line number") {
@@ -414,7 +415,8 @@ class RulesLoadSpec extends AnyFunSuite {
     val file = write(tmpFile(), Seq("+com.example.Config$#apply(*) id:keep-config-apply"))
     val out  = new java.io.ByteArrayOutputStream()
     Console.withOut(out) { Rules.load(file) }
-    assert(out.toString.isEmpty, s"Expected no output, got: ${out.toString}")
+    val warnLines = out.toString.linesIterator.filter(l => l.contains(file.toString) && l.contains("[warn]")).mkString
+    assert(warnLines.isEmpty, s"Expected no [warn] for $file, got: $warnLines")
   }
 
   test("warning emitted for include rule with no id: label") {

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
@@ -354,7 +354,7 @@ class RulesLoadSpec extends AnyFunSuite {
     val file = write(tmpFile(), Seq("com.example.*#copy(*) id:my-rule"))
     val out  = new java.io.ByteArrayOutputStream()
     Console.withOut(out) { Rules.load(file) }
-    val warnLines = out.toString.linesIterator.filter(l => l.contains(file.toString) && l.contains("[warn]")).mkString
+    val warnLines = out.toString.split("\\r?\\n", -1).iterator.filter(l => l.contains(file.toString) && l.contains("[warn]")).mkString
     assert(warnLines.isEmpty, s"Expected no [warn] for $file, got: $warnLines")
   }
 
@@ -406,7 +406,7 @@ class RulesLoadSpec extends AnyFunSuite {
     Console.withOut(out) {
       Rules.parseLine("com.example.*#copy(*)", LocalSource(sourcePath))
     }
-    val relevantLines = out.toString.linesIterator.filter(_.contains(sourcePath)).mkString("\n")
+    val relevantLines = out.toString.split("\\r?\\n", -1).iterator.filter(_.contains(sourcePath)).mkString("\n")
     assert(relevantLines.contains("[warn]"), s"Expected [warn] line for $sourcePath, got: ${out.toString}")
     // Verify no "line N" token appears in lines from this source
     assert(!relevantLines.matches("(?s).*\\bline\\s+\\d+\\b.*"), s"Expected no line number, got: $relevantLines")
@@ -416,7 +416,7 @@ class RulesLoadSpec extends AnyFunSuite {
     val file = write(tmpFile(), Seq("+com.example.Config$#apply(*) id:keep-config-apply"))
     val out  = new java.io.ByteArrayOutputStream()
     Console.withOut(out) { Rules.load(file) }
-    val warnLines = out.toString.linesIterator.filter(l => l.contains(file.toString) && l.contains("[warn]")).mkString
+    val warnLines = out.toString.split("\\r?\\n", -1).iterator.filter(l => l.contains(file.toString) && l.contains("[warn]")).mkString
     assert(warnLines.isEmpty, s"Expected no [warn] for $file, got: $warnLines")
   }
 

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
@@ -429,11 +429,11 @@ class RulesLoadSpec extends AnyFunSuite {
   test("warning emitted for rule with empty id: value (id: with no label)") {
     val file = write(tmpFile(), Seq("com.example.*#copy(*) id:"))
     val out  = new java.io.ByteArrayOutputStream()
-    Console.withOut(out) { Rules.load(file) }
+    val rules = Console.withOut(out) { Rules.load(file) }
     val output = out.toString
     assert(output.contains("[warn]"), s"Expected [warn] when id: has empty value, got: $output")
     // Rule is still valid and returned (empty id treated as no id)
-    assert(Rules.load(file).head.id.isEmpty, "id with empty value must be treated as absent")
+    assert(rules.head.id.isEmpty, "id with empty value must be treated as absent")
   }
 
   test("no warning emitted for rule with non-empty id: value") {

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
@@ -401,14 +401,15 @@ class RulesLoadSpec extends AnyFunSuite {
   }
 
   test("parseLine emits warning with no line number when lineNum is -1") {
+    val sourcePath = "/path/to/rules.txt"
     val out = new java.io.ByteArrayOutputStream()
     Console.withOut(out) {
-      Rules.parseLine("com.example.*#copy(*)", LocalSource("/path/to/rules.txt"))
+      Rules.parseLine("com.example.*#copy(*)", LocalSource(sourcePath))
     }
-    val output = out.toString
-    assert(output.contains("[warn]"))
-    // Verify no "line N" token appears (safe: the source path /path/to/rules.txt contains no "line NN" pattern)
-    assert(!output.matches("(?s).*\\bline\\s+\\d+\\b.*"), s"Expected no line number, got: $output")
+    val relevantLines = out.toString.linesIterator.filter(_.contains(sourcePath)).mkString("\n")
+    assert(relevantLines.contains("[warn]"), s"Expected [warn] line for $sourcePath, got: ${out.toString}")
+    // Verify no "line N" token appears in lines from this source
+    assert(!relevantLines.matches("(?s).*\\bline\\s+\\d+\\b.*"), s"Expected no line number, got: $relevantLines")
   }
 
   test("no warning for include rule with id: label") {

--- a/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
+++ b/rewriter-core/src/test/scala/io/moranaapps/jacocomethodfilter/RulesLoadSpec.scala
@@ -335,4 +335,119 @@ class RulesLoadSpec extends AnyFunSuite {
     val rule = Rules.parseLine("com.example.*#copy(*) forward-compat synthetic id:synth-copy").get
     assert(rule.patternText == "com.example.*#copy(*)")
   }
+
+  // --- no-id warning ---
+
+  test("warns when rule has no id: label") {
+    val file = write(tmpFile(), Seq("com.example.*#copy(*)"))
+    val out  = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) { Rules.load(file) }
+    val output = out.toString
+    assert(output.contains("[warn]"), s"Expected [warn] in output, got: $output")
+    assert(output.contains("no id: label"), s"Expected 'no id: label' in output, got: $output")
+    assert(output.contains("com.example.*#copy(*)"), s"Expected pattern in output, got: $output")
+    assert(output.contains(file.toString), s"Expected file path in output, got: $output")
+    assert(output.contains("line 1"), s"Expected 'line 1' in output, got: $output")
+  }
+
+  test("no warning emitted for rule with id: label") {
+    val file = write(tmpFile(), Seq("com.example.*#copy(*) id:my-rule"))
+    val out  = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) { Rules.load(file) }
+    assert(out.toString.isEmpty, s"Expected no output, got: ${out.toString}")
+  }
+
+  test("warning includes source file path and line number") {
+    val file = write(tmpFile(), Seq(
+      "# comment",                              // line 1 — skipped
+      "com.example.*#foo(*) id:labelled",        // line 2 — no warning
+      "com.example.*#bar(*)"                     // line 3 — no id → warn
+    ))
+    val out = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) { Rules.load(file) }
+    val output = out.toString
+    assert(output.contains(file.toString), s"Expected file path in output, got: $output")
+    assert(output.contains("line 3"), s"Expected 'line 3' in output, got: $output")
+  }
+
+  test("warning message includes Add id label hint") {
+    val file = write(tmpFile(), Seq("com.example.*#bar(*)"))
+    val out  = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) { Rules.load(file) }
+    assert(out.toString.contains("Add id:"), s"Expected 'Add id:' hint in output, got: ${out.toString}")
+  }
+
+  test("parseLine emits warning for unlabelled rule called directly") {
+    val out = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) {
+      Rules.parseLine("com.example.*#copy(*)", LocalSource("/path/to/rules.txt"), lineNum = 5)
+    }
+    val output = out.toString
+    assert(output.contains("[warn]"))
+    assert(output.contains("/path/to/rules.txt"))
+    assert(output.contains("line 5"))
+  }
+
+  test("parseLine emits warning with GlobalSource origin") {
+    val out = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) {
+      Rules.parseLine("com.example.*#copy(*)", GlobalSource("https://example.com/rules.txt"), lineNum = 2)
+    }
+    val output = out.toString
+    assert(output.contains("[warn]"))
+    assert(output.contains("https://example.com/rules.txt"))
+    assert(output.contains("line 2"))
+  }
+
+  test("parseLine emits warning with no line number when lineNum is -1") {
+    val out = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) {
+      Rules.parseLine("com.example.*#copy(*)", LocalSource("/path/to/rules.txt"))
+    }
+    val output = out.toString
+    assert(output.contains("[warn]"))
+    // Verify no "line N" token appears (safe: the source path /path/to/rules.txt contains no "line NN" pattern)
+    assert(!output.matches("(?s).*\\bline\\s+\\d+\\b.*"), s"Expected no line number, got: $output")
+  }
+
+  test("no warning for include rule with id: label") {
+    val file = write(tmpFile(), Seq("+com.example.Config$#apply(*) id:keep-config-apply"))
+    val out  = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) { Rules.load(file) }
+    assert(out.toString.isEmpty, s"Expected no output, got: ${out.toString}")
+  }
+
+  test("warning emitted for include rule with no id: label") {
+    val file = write(tmpFile(), Seq("+com.example.Config$#apply(*)"))
+    val out  = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) { Rules.load(file) }
+    val output = out.toString
+    assert(output.contains("[warn]"), s"Expected [warn] in output, got: $output")
+    assert(output.contains("+com.example.Config$#apply(*)"), s"Expected pattern in output, got: $output")
+  }
+
+  test("warning emitted for rule with empty id: value (id: with no label)") {
+    val file = write(tmpFile(), Seq("com.example.*#copy(*) id:"))
+    val out  = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) { Rules.load(file) }
+    val output = out.toString
+    assert(output.contains("[warn]"), s"Expected [warn] when id: has empty value, got: $output")
+    // Rule is still valid and returned (empty id treated as no id)
+    assert(Rules.load(file).head.id.isEmpty, "id with empty value must be treated as absent")
+  }
+
+  test("no warning emitted for rule with non-empty id: value") {
+    val rule = Rules.parseLine("com.example.*#copy(*) id:my-label").get
+    assert(rule.id.contains("my-label"))
+  }
+
+  test("loadAll emits warning for unlabelled rule from global source") {
+    val globalFile = write(tmpFile("global-"), Seq("com.example.*#foo(*)")) // no id
+    val localFile  = write(tmpFile("local-"),  Seq("com.example.*#bar(*) id:local-rule"))
+    val out  = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) { Rules.loadAll(Some(globalFile.toString), Some(localFile)) }
+    val output = out.toString
+    assert(output.contains("[warn]"), s"Expected [warn] for global unlabelled rule, got: $output")
+    assert(output.contains(globalFile.toString), s"Expected global file path in [warn], got: $output")
+  }
 }


### PR DESCRIPTION
### Summary

Emits a `[warn]` at load time when a rule has no `id:` label, and adds a `--strict` CLI flag that exits non-zero when any unlabelled rules are found.

---

### Changes

#### Core (`Rules.scala`)
- `parseLine` gains a `lineNum` parameter; emits `[warn]` for every rule where `id` is absent or empty:
  ```
  [warn] /path/jmf-rules.txt line 3: rule has no id: label (*#copy(*)). Add id:<label> for traceability.
  ```
- `id:` with an empty value (e.g. `id:`) is treated as absent — `id = None`
- `load`, `loadFromUrl`, `loadFromPath` pass 1-indexed line numbers to `parseLine`
- Removed unreachable `case _` in sealed-trait match; fixed variable shadow in `loadFromUrl`

#### CLI (`CoverageRewriter.scala`, `CoverageRewriterCli.scala`)
- `CliConfig` gains `strict: Boolean = false`
- Both `run()` and `verify()` check `strict` after `loadAll()` and call `sys.exit(1)` when any rule has no `id:`; the check runs before scanning, so `--error-on-unmatched` is never evaluated when `--strict` already fails
- `--strict` option added to the CLI parser

#### Tests (`RulesLoadSpec.scala`, `CoverageRewriterCliSpec.scala`)
- 15 new unit tests covering: `[warn]` with file path + line number + pattern; no warning for labelled rules; `id:` empty value warns; `loadAll` warns for global-source unlabelled rules; `parseLine` direct calls with/without `lineNum`; include-rule labelling; `--strict` CLI parsing (default false, all modes, combined with `--error-on-unmatched`)

#### Integration test (`integration-tests/test-cli-strict.sh`)
- 8 test cases:
  1. `[warn]` emitted at load time (without `--strict`)
  2. No `[warn]` when all rules are labelled
  3. `--strict` exits non-zero on unlabelled rules
  4. `--strict` exits zero when all rules labelled
  5. Rewrite mode + `--strict` aborts before creating the output directory
  6. `[warn]` contains file path and line number
  7. `[error]` message reports correct unlabelled-rule count
  8. Combined `--strict` + `--error-on-unmatched` — strict check runs first

#### Docs (`docs/rules-reference.md`, `jmf-rules.template.txt`, `maven-plugin/.../jmf-rules.template.txt`)
- **Common Pitfalls §5** — `[warn]` fires regardless of `--strict`; `--strict` usage example added
- **Verify section** — `--strict` flag documented; precedence note when combined with `--error-on-unmatched`
- **How to Use** — step added for `--strict` CI enforcement; note that sbt/Maven plugins do not yet expose `--strict` as a config key
- **CLI Reference table** — `--strict` row added
- **Rule Anatomy** — `id:<non-empty-string>`; empty value treated as absent
- **Maven template** — HOW TO USE section updated to match sbt template

---

### Backward compatibility

- Rules without `id:` continue to load and match as before — warning only, no parse failure
- No change to rule syntax, matching semantics, CLI exit codes for existing flags, or artifact coordinates


Release Notes:
- `[warn]` emitted at load time for every rule missing an `id:` label (includes source file path and line number)
- `id:` with empty value treated as absent (equivalent to omitting `id:`)
- New `--strict` CLI flag — exits `1` if any rules lack an `id:` label; works in rewrite and verify modes
- When `--strict` and `--error-on-unmatched` are both set, `--strict` check runs first
- `jmf-rules.template.txt` (sbt + Maven) and `docs/rules-reference.md` updated to document the above

Closes #62
